### PR TITLE
카카오 로그인을 위한 토큰 유효성 검사 로직 구현

### DIFF
--- a/backend/src/main/java/kr/co/yigil/global/exception/InvalidTokenException.java
+++ b/backend/src/main/java/kr/co/yigil/global/exception/InvalidTokenException.java
@@ -7,5 +7,6 @@ public class InvalidTokenException extends AuthException {
 
     public InvalidTokenException(final ExceptionCode exceptionCode) {
         super(exceptionCode);
+
     }
 }

--- a/backend/src/main/java/kr/co/yigil/login/application/strategy/GoogleLoginStrategy.java
+++ b/backend/src/main/java/kr/co/yigil/login/application/strategy/GoogleLoginStrategy.java
@@ -4,7 +4,7 @@ import kr.co.yigil.login.dto.request.LoginRequest;
 import kr.co.yigil.login.dto.response.GoogleLoginResponse;
 import kr.co.yigil.login.dto.response.LoginResponse;
 
-public class GoogleLoginStratgy implements LoginStrategy{
+public class GoogleLoginStrategy implements LoginStrategy{
 
     @Override
     public LoginResponse login(LoginRequest request, String accessToken) {

--- a/backend/src/main/java/kr/co/yigil/login/application/strategy/KakaoLoginStrategy.java
+++ b/backend/src/main/java/kr/co/yigil/login/application/strategy/KakaoLoginStrategy.java
@@ -2,18 +2,27 @@ package kr.co.yigil.login.application.strategy;
 
 import static kr.co.yigil.global.exception.ExceptionCode.INVALID_ACCESS_TOKEN;
 
+import java.util.Collections;
 import kr.co.yigil.global.exception.InvalidTokenException;
 import kr.co.yigil.login.dto.request.KakaoLoginRequest;
 import kr.co.yigil.login.dto.request.LoginRequest;
 import kr.co.yigil.login.dto.response.KakaoLoginResponse;
+import kr.co.yigil.login.dto.response.KakaoTokenInfoResponse;
 import kr.co.yigil.login.dto.response.LoginResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 @PropertySource("classpath:url.properties")
 public class KakaoLoginStrategy implements LoginStrategy {
 
-    private final String PROVIDER_NAME = "kakao";
+    private static final String PROVIDER_NAME = "kakao";
 
     @Value("${Kakao-Token-Info-Url}")
     private String KAKAO_TOKEN_INFO_URL;
@@ -22,7 +31,7 @@ public class KakaoLoginStrategy implements LoginStrategy {
     public LoginResponse login(LoginRequest request, String accessToken) {
         KakaoLoginRequest loginRequest = (KakaoLoginRequest) request;
 
-        if(!isTokenValid(accessToken)) {
+        if(!isTokenValid(accessToken, loginRequest.getId())) {
             throw new InvalidTokenException(INVALID_ACCESS_TOKEN);
         }
         return new KakaoLoginResponse();
@@ -33,8 +42,23 @@ public class KakaoLoginStrategy implements LoginStrategy {
         return PROVIDER_NAME;
     }
 
-    private boolean isTokenValid(String accessToken) {
-        return true;
+    private boolean isTokenValid(String accessToken, Long expectedUserId) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoTokenInfoResponse> response = restTemplate.exchange(
+                    KAKAO_TOKEN_INFO_URL, HttpMethod.GET, entity, KakaoTokenInfoResponse.class);
+
+            KakaoTokenInfoResponse tokenInfo = response.getBody();
+            return tokenInfo != null && tokenInfo.getId().equals(expectedUserId);
+        } catch (Exception e) {
+            return false;
+        }
     }
 
 }

--- a/backend/src/main/java/kr/co/yigil/login/application/strategy/KakaoLoginStrategy.java
+++ b/backend/src/main/java/kr/co/yigil/login/application/strategy/KakaoLoginStrategy.java
@@ -9,6 +9,7 @@ import kr.co.yigil.login.dto.request.LoginRequest;
 import kr.co.yigil.login.dto.response.KakaoLoginResponse;
 import kr.co.yigil.login.dto.response.KakaoTokenInfoResponse;
 import kr.co.yigil.login.dto.response.LoginResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpEntity;
@@ -17,14 +18,17 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+@Service
+@Slf4j
 @PropertySource("classpath:url.properties")
 public class KakaoLoginStrategy implements LoginStrategy {
 
     private static final String PROVIDER_NAME = "kakao";
 
-    @Value("${Kakao-Token-Info-Url}")
+    @Value("${kakao.token.info.url}")
     private String KAKAO_TOKEN_INFO_URL;
 
     @Override
@@ -43,6 +47,11 @@ public class KakaoLoginStrategy implements LoginStrategy {
     }
 
     private boolean isTokenValid(String accessToken, Long expectedUserId) {
+        KakaoTokenInfoResponse tokenInfo = requestKakaoTokenInfo(accessToken);
+        return isUserIdValid(tokenInfo, expectedUserId);
+    }
+
+    private KakaoTokenInfoResponse requestKakaoTokenInfo(String accessToken) {
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
@@ -52,13 +61,17 @@ public class KakaoLoginStrategy implements LoginStrategy {
 
         try {
             ResponseEntity<KakaoTokenInfoResponse> response = restTemplate.exchange(
-                    KAKAO_TOKEN_INFO_URL, HttpMethod.GET, entity, KakaoTokenInfoResponse.class);
-
-            KakaoTokenInfoResponse tokenInfo = response.getBody();
-            return tokenInfo != null && tokenInfo.getId().equals(expectedUserId);
+                    KAKAO_TOKEN_INFO_URL, HttpMethod.GET, entity, KakaoTokenInfoResponse.class
+            );
+            return response.getBody();
         } catch (Exception e) {
-            return false;
+            log.warn(e.getMessage(), e);
+            throw new InvalidTokenException(INVALID_ACCESS_TOKEN);
         }
+    }
+
+    private boolean isUserIdValid(KakaoTokenInfoResponse tokenInfo, Long expectedUserId) {
+        return tokenInfo != null && tokenInfo.getId().equals(expectedUserId);
     }
 
 }

--- a/backend/src/main/java/kr/co/yigil/login/application/strategy/KakaoLoginStrategy.java
+++ b/backend/src/main/java/kr/co/yigil/login/application/strategy/KakaoLoginStrategy.java
@@ -38,6 +38,8 @@ public class KakaoLoginStrategy implements LoginStrategy {
         if(!isTokenValid(accessToken, loginRequest.getId())) {
             throw new InvalidTokenException(INVALID_ACCESS_TOKEN);
         }
+
+
         return new KakaoLoginResponse();
     }
 

--- a/backend/src/main/java/kr/co/yigil/login/application/strategy/LoginStrategy.java
+++ b/backend/src/main/java/kr/co/yigil/login/application/strategy/LoginStrategy.java
@@ -6,4 +6,5 @@ import kr.co.yigil.login.dto.response.LoginResponse;
 public interface LoginStrategy {
     LoginResponse login(LoginRequest request, String accessToken);
     String getProviderName();
+    
 }

--- a/backend/src/main/java/kr/co/yigil/login/dto/request/KakaoLoginRequest.java
+++ b/backend/src/main/java/kr/co/yigil/login/dto/request/KakaoLoginRequest.java
@@ -1,5 +1,8 @@
 package kr.co.yigil.login.dto.request;
 
-public class KakaoLoginRequest {
+import lombok.Data;
 
+@Data
+public class KakaoLoginRequest {
+    private Long id;
 }

--- a/backend/src/main/java/kr/co/yigil/login/dto/response/KakaoTokenInfoResponse.java
+++ b/backend/src/main/java/kr/co/yigil/login/dto/response/KakaoTokenInfoResponse.java
@@ -1,0 +1,10 @@
+package kr.co.yigil.login.dto.response;
+
+import lombok.Data;
+
+@Data
+public class KakaoTokenInfoResponse {
+    private Long id;
+    private int expiresIn;
+    private int appId;
+}

--- a/backend/src/main/resources/url.properties
+++ b/backend/src/main/resources/url.properties
@@ -1,1 +1,1 @@
-Kakao-Token-Info-Url=https://kapi.kakao.com/v1/user/access_token_info	
+kakao.token.info.url=https://kapi.kakao.com/v1/user/access_token_info	


### PR DESCRIPTION
## PR Type

카카오 로그인을 위한 토큰 인증 로직을 추가하였습니다

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [ ] 버그를 수정했어요.
- [x] 새로운 기능을 추가했어요.
- [ ] 코드 스타일 업데이트를 했어요(포맷팅, 지역변수)
- [x] 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [ ] 환경설정을 변경했어요.
- [ ] 문서 내용을 변경했어요.
- [ ] 기타 사항을 설명해 주세요.

## Related Issues

#49 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 카카오 서버에 토큰 유효성 검사 요청
- [x] 응답이 유효하다면, 토큰의 Social Id 검증
- [x] 응답이 카카오 서버로 부터 잘 오는지 까지 테스트 완료 (테스트 코드는 로그인 로직 완성 후 작성 필요)

## Other information

호윤님 잘 부탁드립니다 @Uknow928 