### PR TITLE
사용자 팔로우를 위한 api 및 sse를 통한 실시간 알림 기능 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.528'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -47,6 +49,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+	testImplementation 'io.projectreactor:reactor-test:3.4.10'
 
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	implementation 'com.github.maricn:logback-slack-appender:1.6.1'

--- a/backend/src/main/java/kr/co/yigil/follow/application/FollowService.java
+++ b/backend/src/main/java/kr/co/yigil/follow/application/FollowService.java
@@ -1,0 +1,65 @@
+package kr.co.yigil.follow.application;
+
+import static kr.co.yigil.global.exception.ExceptionCode.NOT_FOUND_MEMBER_ID;
+
+import jakarta.transaction.Transactional;
+import kr.co.yigil.follow.domain.Follow;
+import kr.co.yigil.follow.domain.repository.FollowCountRedisRepository;
+import kr.co.yigil.follow.domain.repository.FollowCountRepository;
+import kr.co.yigil.follow.domain.repository.FollowRepository;
+import kr.co.yigil.follow.dto.response.FollowResponse;
+import kr.co.yigil.follow.dto.response.UnfollowResponse;
+import kr.co.yigil.global.exception.BadRequestException;
+import kr.co.yigil.member.domain.Member;
+import kr.co.yigil.member.domain.repository.MemberRepository;
+import kr.co.yigil.notification.application.NotificationService;
+import kr.co.yigil.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final FollowCountRedisRepository followCountRedisRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
+
+    @Transactional
+    public FollowResponse follow(final Long followerId, final Long followingId) {
+        Member follower = getMemberById(followerId);
+        Member following = getMemberById(followingId);
+
+        followRepository.save(new Follow(follower, following));
+        followCountRedisRepository.incrementFollowersCount(followingId);
+        followCountRedisRepository.incrementFollowingsCount(followerId);
+
+        sendFollowNotification(follower, following);
+
+        return new FollowResponse("팔로우가 완료되었습니다.");
+    }
+
+    @Transactional
+    public UnfollowResponse unfollow(final Long followerId, final Long followingId) {
+        Member unfollower = getMemberById(followerId);
+        Member unfollowing = getMemberById(followingId);
+
+        followRepository.deleteByFollowerAndFollowing(unfollower, unfollowing);
+        followCountRedisRepository.decrementFollowersCount(followingId);
+        followCountRedisRepository.decrementFollowingsCount(followerId);
+        return new UnfollowResponse("팔로우가 취소되었습니다.");
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER_ID));
+    }
+
+    private void sendFollowNotification(Member follower, Member following) {
+        String message = follower.getNickname() + "님이 팔로우 하였습니다.";
+        Notification notify = new Notification(following, message);
+        notificationService.sendNotification(notify);
+    }
+}
+

--- a/backend/src/main/java/kr/co/yigil/follow/domain/Follow.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/Follow.java
@@ -1,0 +1,34 @@
+package kr.co.yigil.follow.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.yigil.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "follower_id")
+    private Member follower;
+
+    @ManyToOne
+    @JoinColumn(name = "following_id")
+    private Member following;
+
+    public Follow(final Member follower, final Member following) {
+        this.follower = follower;
+        this.following = following;
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/follow/domain/FollowCount.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/FollowCount.java
@@ -1,0 +1,20 @@
+package kr.co.yigil.follow.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@AllArgsConstructor
+@RedisHash("followCount")
+public class FollowCount {
+
+    @Id
+    private Long memberId;
+
+    private int followerCount;
+
+    private int followingCount;
+}

--- a/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowCountRedisRepository.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowCountRedisRepository.java
@@ -1,0 +1,32 @@
+package kr.co.yigil.follow.domain.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowCountRedisRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void incrementFollowersCount(Long memberId) {
+        redisTemplate.opsForHash().increment("followCount", buildHashKey(memberId, "followerCount"), 1);
+    }
+
+    public void decrementFollowersCount(Long memberId) {
+        redisTemplate.opsForHash().increment("followCount", buildHashKey(memberId, "followerCount"), -1);
+    }
+
+    public void incrementFollowingsCount(Long memberId) {
+        redisTemplate.opsForHash().increment("followCount", buildHashKey(memberId, "followingCount"), 1);
+    }
+
+    public void decrementFollowingsCount(Long memberId) {
+        redisTemplate.opsForHash().increment("followCount", buildHashKey(memberId, "followingCount"), -1);
+    }
+
+    private String buildHashKey(Long memberId, String fieldName) {
+        return memberId + ":" + fieldName;
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowCountRepository.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowCountRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yigil.follow.domain.repository;
+
+
+import kr.co.yigil.follow.domain.FollowCount;
+import org.springframework.data.repository.CrudRepository;
+
+public interface FollowCountRepository extends CrudRepository<FollowCount, Long> {
+
+}

--- a/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
@@ -1,0 +1,10 @@
+package kr.co.yigil.follow.domain.repository;
+
+import kr.co.yigil.follow.domain.Follow;
+import kr.co.yigil.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    public void deleteByFollowerAndFollowing(Member Follower, Member Following);
+}

--- a/backend/src/main/java/kr/co/yigil/follow/dto/response/FollowResponse.java
+++ b/backend/src/main/java/kr/co/yigil/follow/dto/response/FollowResponse.java
@@ -1,0 +1,13 @@
+package kr.co.yigil.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowResponse {
+
+    private String message;
+}

--- a/backend/src/main/java/kr/co/yigil/follow/dto/response/UnfollowResponse.java
+++ b/backend/src/main/java/kr/co/yigil/follow/dto/response/UnfollowResponse.java
@@ -1,0 +1,14 @@
+package kr.co.yigil.follow.dto.response;
+
+import jakarta.persistence.NamedStoredProcedureQueries;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UnfollowResponse {
+
+    private String message;
+}

--- a/backend/src/main/java/kr/co/yigil/follow/presentation/FollowController.java
+++ b/backend/src/main/java/kr/co/yigil/follow/presentation/FollowController.java
@@ -1,0 +1,36 @@
+package kr.co.yigil.follow.presentation;
+
+import kr.co.yigil.auth.Auth;
+import kr.co.yigil.auth.MemberOnly;
+import kr.co.yigil.auth.domain.Accessor;
+import kr.co.yigil.follow.application.FollowService;
+import kr.co.yigil.follow.dto.response.FollowResponse;
+import kr.co.yigil.follow.dto.response.UnfollowResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/api/v1/follow/{memberId}")
+    @MemberOnly
+    public ResponseEntity<FollowResponse> follow(@Auth final Accessor accessor,
+            @PathVariable("memberId") final Long memberId) {
+        FollowResponse response = followService.follow(accessor.getMemberId(), memberId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/api/v1/unfollow/{memberId}")
+    @MemberOnly
+    public ResponseEntity<UnfollowResponse> unfollow(@Auth final Accessor accessor,
+            @PathVariable("memberId") final Long memberId) {
+        UnfollowResponse response = followService.unfollow(accessor.getMemberId(), memberId);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/global/config/RedisConfig.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/RedisConfig.java
@@ -6,12 +6,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration
+@EnableRedisRepositories
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
@@ -25,11 +28,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
         return redisTemplate;
     }
 

--- a/backend/src/main/java/kr/co/yigil/global/log/interceptor/ConnectionProxyHandler.java
+++ b/backend/src/main/java/kr/co/yigil/global/log/interceptor/ConnectionProxyHandler.java
@@ -10,7 +10,7 @@ import org.springframework.aop.framework.ProxyFactory;
 @RequiredArgsConstructor
 public class ConnectionProxyHandler implements MethodInterceptor {
 
-    private static final String JDBC_PREPATE_STATEMENT_METHOD_NAME = "prepareStatement";
+    private static final String JDBC_PREPARE_STATEMENT_METHOD_NAME = "prepareStatement";
 
     private final Object connection;
     private final LoggingForm loggingForm;
@@ -33,7 +33,7 @@ public class ConnectionProxyHandler implements MethodInterceptor {
     }
 
     private boolean hasPreparedStatementInvoked(final MethodInvocation invocation) {
-        return invocation.getMethod().getName().equals(JDBC_PREPATE_STATEMENT_METHOD_NAME);
+        return invocation.getMethod().getName().equals(JDBC_PREPARE_STATEMENT_METHOD_NAME);
     }
 
     public Object getProxy() {

--- a/backend/src/main/java/kr/co/yigil/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/kr/co/yigil/member/domain/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import kr.co.yigil.member.domain.Member;
 import kr.co.yigil.member.domain.SocialLoginType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 public interface MemberRepository extends JpaRepository <Member, Long> {
 

--- a/backend/src/main/java/kr/co/yigil/member/presentation/MemberController.java
+++ b/backend/src/main/java/kr/co/yigil/member/presentation/MemberController.java
@@ -48,8 +48,8 @@ public class MemberController {
     }
 
 
-    @GetMapping("/api/v1/member/{member_id}")
-    public ResponseEntity<MemberInfoResponse> getMemberInfo(@PathVariable("member_id") final Long memberId) {
+    @GetMapping("/api/v1/member/{memberId}")
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(@PathVariable("memberId") final Long memberId) {
         MemberInfoResponse response = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/kr/co/yigil/notification/application/NotificationService.java
+++ b/backend/src/main/java/kr/co/yigil/notification/application/NotificationService.java
@@ -1,0 +1,35 @@
+package kr.co.yigil.notification.application;
+
+import kr.co.yigil.notification.domain.Notification;
+import kr.co.yigil.notification.domain.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final Sinks.Many<Notification> sink = Sinks.many().multicast().onBackpressureBuffer();
+    private final NotificationRepository notificationRepository;
+
+    public void sendNotification(Notification notification) {
+        notificationRepository.save(notification);
+        sendRealTimeNotification(notification);
+    }
+
+    private void sendRealTimeNotification(Notification notification) {
+        sink.tryEmitNext(notification);
+    }
+
+    public Flux<ServerSentEvent<Notification>> getNotificationStream(Long memberId) {
+        return sink.asFlux()
+                .filter(notification -> notification.getMember().getId().equals(memberId))
+                .map(notification -> ServerSentEvent.<Notification>builder()
+                        .data(notification)
+                        .build());
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/notification/domain/Notification.java
+++ b/backend/src/main/java/kr/co/yigil/notification/domain/Notification.java
@@ -1,0 +1,49 @@
+package kr.co.yigil.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.yigil.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name ="member_id")
+    private Member member;
+
+    private String message;
+
+    private boolean isRead;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    public Notification(final Member member, final String message) {
+        this.member = member;
+        this.message = message;
+        isRead = false;
+        createdAt = LocalDateTime.now();
+        modifiedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/notification/domain/repository/NotificationRepository.java
+++ b/backend/src/main/java/kr/co/yigil/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package kr.co.yigil.notification.domain.repository;
+
+import kr.co.yigil.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/backend/src/main/java/kr/co/yigil/notification/presentation/NotificationController.java
+++ b/backend/src/main/java/kr/co/yigil/notification/presentation/NotificationController.java
@@ -1,0 +1,26 @@
+package kr.co.yigil.notification.presentation;
+
+import kr.co.yigil.auth.Auth;
+import kr.co.yigil.auth.MemberOnly;
+import kr.co.yigil.auth.domain.Accessor;
+import kr.co.yigil.notification.application.NotificationService;
+import kr.co.yigil.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(path = "/api/v1/notifications/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @MemberOnly
+    public Flux<ServerSentEvent<Notification>> streamNotifications(@Auth Accessor accessor) {
+        return notificationService.getNotificationStream(accessor.getMemberId());
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/travel/domain/Travel.java
+++ b/backend/src/main/java/kr/co/yigil/travel/domain/Travel.java
@@ -41,5 +41,7 @@ public abstract class Travel {
 
     protected Travel(final Member member) {
         this.member = member;
+        createdAt = LocalDateTime.now();
+        modifiedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/test/java/kr/co/yigil/follow/application/FollowServiceTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/application/FollowServiceTest.java
@@ -1,0 +1,94 @@
+package kr.co.yigil.follow.application;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import kr.co.yigil.follow.domain.Follow;
+import kr.co.yigil.follow.domain.repository.FollowCountRedisRepository;
+import kr.co.yigil.follow.domain.repository.FollowRepository;
+import kr.co.yigil.global.exception.BadRequestException;
+import kr.co.yigil.member.domain.Member;
+import kr.co.yigil.member.domain.SocialLoginType;
+import kr.co.yigil.member.domain.repository.MemberRepository;
+import kr.co.yigil.notification.application.NotificationService;
+import kr.co.yigil.notification.domain.Notification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class FollowServiceTest {
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private FollowCountRedisRepository followCountRedisRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private FollowService followService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("follow 메서드가 팔로우를 잘 저장하고 알림을 잘 보내는지")
+    @Test
+    void whenFollow_ShouldSaveFollowAndSendNotification() {
+        Long followerId = 1L;
+        Long followingId = 1L;
+        Member follower = new Member(followerId, "email", "12345678", "follower", "image.jpg", SocialLoginType.KAKAO);
+        Member following = new Member(followingId, "email2", "87654321", "following", "profile.png", SocialLoginType.KAKAO);
+
+        when(memberRepository.findById(followerId)).thenReturn(Optional.of(follower));
+        when(memberRepository.findById(followingId)).thenReturn(Optional.of(following));
+
+        followService.follow(followerId, followingId);
+
+        verify(followRepository, times(1)).save(any(Follow.class));
+        verify(followCountRedisRepository, times(1)).incrementFollowersCount(followingId);
+        verify(followCountRedisRepository, times(1)).incrementFollowingsCount(followerId);
+        verify(notificationService, times(1)).sendNotification(any(Notification.class));
+    }
+
+    @DisplayName("follow 메서드가 존재하지 않는 사용자에 대한 요청을 보냈을 때 예외가 잘 발생하는지")
+    @Test
+    void whenFollowWithInvalidMemberInfo_ShouldThrowException() {
+        Long nonExistingId = 3L;
+
+        when(memberRepository.findById(nonExistingId)).thenReturn(Optional.empty());
+
+        assertThrows(BadRequestException.class, () -> followService.follow(1L, nonExistingId));
+    }
+
+    @DisplayName("unfollow 메서드가 팔로우를 잘 삭제하는지")
+    @Test
+    void whenUnfollow_ShouldDeleteFollow() {
+        Long followerId = 1L;
+        Long followingId = 2L;
+        Member unfollower = new Member(followerId, "email", "12345678", "follower", "image.jpg", SocialLoginType.KAKAO);
+        Member unfollowing = new Member(followingId, "email2", "87654321", "following", "profile.png", SocialLoginType.KAKAO);
+
+        when(memberRepository.findById(followerId)).thenReturn(Optional.of(unfollower));
+        when(memberRepository.findById(followingId)).thenReturn(Optional.of(unfollowing));
+
+        followService.unfollow(followerId, followingId);
+
+        verify(followRepository, times(1)).deleteByFollowerAndFollowing(unfollower, unfollowing);
+        verify(followCountRedisRepository, times(1)).decrementFollowersCount(followingId);
+        verify(followCountRedisRepository, times(1)).decrementFollowingsCount(followerId);
+    }
+}

--- a/backend/src/test/java/kr/co/yigil/follow/presentation/FollowControllerTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/presentation/FollowControllerTest.java
@@ -1,0 +1,68 @@
+package kr.co.yigil.follow.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import kr.co.yigil.follow.application.FollowService;
+import kr.co.yigil.follow.dto.response.FollowResponse;
+import kr.co.yigil.follow.dto.response.UnfollowResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(FollowController.class)
+public class FollowControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FollowService followService;
+
+    @InjectMocks
+    private FollowController followController;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("팔로우가 요청되었을 때 200 응답과 response가 잘 반환되는지")
+    @Test
+    void whenFollow_thenReturns200AndFollowResponse() throws Exception {
+        Long accessorId = 1L;
+        Long memberId = 2L;
+        FollowResponse mockResponse = new FollowResponse();
+
+        given(followService.follow(accessorId, memberId)).willReturn(mockResponse);
+
+        mockMvc.perform(post("/api/v1/follow/" + memberId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("언팔로우가 요청되었을 때 200 응답과 Response가 잘 반환되는지")
+    @Test
+    void whenUnfollow_thenReturns200AndUnfollowResponse() throws Exception {
+        Long accessorId = 1L;
+        Long memberId = 2L;
+        UnfollowResponse mockResponse = new UnfollowResponse();
+
+        given(followService.unfollow(accessorId, memberId)).willReturn(mockResponse);
+
+        mockMvc.perform(post("/api/v1/unfollow/" + memberId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/kr/co/yigil/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/kr/co/yigil/notification/application/NotificationServiceTest.java
@@ -1,0 +1,59 @@
+package kr.co.yigil.notification.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import kr.co.yigil.member.domain.Member;
+import kr.co.yigil.member.domain.SocialLoginType;
+import kr.co.yigil.notification.domain.Notification;
+import kr.co.yigil.notification.domain.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+public class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        notificationService = new NotificationService(notificationRepository);
+    }
+
+    @Test
+    @DisplayName("알림을 보내고 저장하는지 확인")
+    void testSendNotification() {
+        Member member = new Member(1L, "email", "12345678", "nickname", "image.jpg", SocialLoginType.KAKAO);
+        Notification notification = new Notification(member, "새 알림");
+
+        notificationService.sendNotification(notification);
+
+        verify(notificationRepository).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("특정 회원 ID에 대한 알림 스트림을 올바르게 반환하는지 확인")
+    void testGetNotificationStream() {
+        Long memberId = 1L;
+        Member member = new Member(memberId, "email@example.com", "1234", "nickname", "profile.jpg", SocialLoginType.KAKAO);
+        Notification notification = new Notification(member, "새 알림");
+
+        notificationService.sendNotification(notification);
+
+        Flux<ServerSentEvent<Notification>> stream = notificationService.getNotificationStream(memberId);
+
+        StepVerifier.create(stream)
+                .expectNextMatches(sse -> sse.data().equals(notification))
+                .thenCancel()
+                .verify();
+    }
+}

--- a/backend/src/test/java/kr/co/yigil/notification/presentation/NotificationControllerTest.java
+++ b/backend/src/test/java/kr/co/yigil/notification/presentation/NotificationControllerTest.java
@@ -1,0 +1,49 @@
+package kr.co.yigil.notification.presentation;
+
+import kr.co.yigil.member.domain.Member;
+import kr.co.yigil.member.domain.SocialLoginType;
+import kr.co.yigil.notification.application.NotificationService;
+import kr.co.yigil.notification.domain.Notification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import reactor.core.publisher.Flux;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(NotificationController.class)
+public class NotificationControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @DisplayName("Notification stream이 올바르게 반환되는지 테스트")
+    @Test
+    void testStreamNotifications() throws Exception {
+        Member member = new Member(1L, "email", "12345678", "nickname", "image.jpg", SocialLoginType.KAKAO);
+        Notification notification = new Notification(member, "새로운 알림입니다.");
+        Flux<ServerSentEvent<Notification>> notificationFlux = Flux.just(ServerSentEvent.builder(notification).build());
+
+        Mockito.when(notificationService.getNotificationStream(member.getId())).thenReturn(notificationFlux);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/notifications/stream"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+   }
+}


### PR DESCRIPTION
## Motivation 🧐
- 사용자 팔로우 팔로잉 기능 / 언팔로우 언팔로잉 기능 및 팔로우 시 실시간 알림 기능을 개발했습니다.
<br>

## Key Changes 🔑
- 팔로우 팔로잉 기능을 위한 follow 도메인 및 기능 개발
- 성능 개선을 위한 팔로우 카운트 데이터를 캐싱 및 Redis에 저장
- 팔로우 발생 시 실시간 사용자에게 알림 생성 및 SSE / Spring-WebFlux / Reactor 를 활용한 알림 구독 기능 개발
<br>

## To Reviewers 🙏
- 리뷰 부탁드립니다.. (다음부턴 더 작은 단위로 Pr 날리도록 하겠습니다..)
- 프론트에서 SSE 이벤트 구독을 통한 실시간 알림 테스트가 필요합니다.
