### PR TITLE
사용자 팔로우 리스트 조회를 위한 api 및 redis 데이터 동기화 로직 작성

### DIFF
--- a/backend/src/main/java/kr/co/yigil/follow/application/FollowRedisIntegrityService.java
+++ b/backend/src/main/java/kr/co/yigil/follow/application/FollowRedisIntegrityService.java
@@ -1,0 +1,31 @@
+package kr.co.yigil.follow.application;
+
+import kr.co.yigil.follow.domain.FollowCount;
+import kr.co.yigil.follow.domain.repository.FollowRepository;
+import kr.co.yigil.follow.dto.FollowCountDto;
+import kr.co.yigil.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowRedisIntegrityService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final FollowRepository followRepository;
+
+    public void ensureFollowCounts(Member member) {
+        Long memberId = member.getId();
+        Boolean exists = redisTemplate.hasKey("followCount:" + memberId);
+        if(Boolean.FALSE.equals(exists)) {
+            FollowCount followCount = getFollowCount(member);
+            redisTemplate.opsForValue().set("followCount:" + memberId, followCount);
+        }
+    }
+
+    private FollowCount getFollowCount(Member member) {
+        FollowCountDto followCountDto = followRepository.getFollowCounts(member);
+        return new FollowCount(member.getId(), followCountDto.getFollowerCount(),
+                followCountDto.getFollowingCount());
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/follow/application/FollowService.java
+++ b/backend/src/main/java/kr/co/yigil/follow/application/FollowService.java
@@ -25,11 +25,15 @@ public class FollowService {
     private final FollowCountRedisRepository followCountRedisRepository;
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
+    private final FollowRedisIntegrityService followRedisIntegrityService;
 
     @Transactional
     public FollowResponse follow(final Long followerId, final Long followingId) {
         Member follower = getMemberById(followerId);
         Member following = getMemberById(followingId);
+
+        followRedisIntegrityService.ensureFollowCounts(follower);
+        followRedisIntegrityService.ensureFollowCounts(following);
 
         followRepository.save(new Follow(follower, following));
         followCountRedisRepository.incrementFollowersCount(followingId);
@@ -44,6 +48,9 @@ public class FollowService {
     public UnfollowResponse unfollow(final Long followerId, final Long followingId) {
         Member unfollower = getMemberById(followerId);
         Member unfollowing = getMemberById(followingId);
+
+        followRedisIntegrityService.ensureFollowCounts(unfollower);
+        followRedisIntegrityService.ensureFollowCounts(unfollowing);
 
         followRepository.deleteByFollowerAndFollowing(unfollower, unfollowing);
         followCountRedisRepository.decrementFollowersCount(followingId);

--- a/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
@@ -1,5 +1,6 @@
 package kr.co.yigil.follow.domain.repository;
 
+import java.util.List;
 import kr.co.yigil.follow.domain.Follow;
 import kr.co.yigil.follow.dto.FollowCountDto;
 import kr.co.yigil.member.domain.Member;
@@ -9,9 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
+    public List<Follow> findAllByFollowing(Member member);
 
-    public int countAllByFollowing(Member member);
-    public int countAllByFollower(Member member);
+    public List<Follow> findAllByFollower(Member member);
 
     @Query("SELECT new kr.co.yigil.follow.dto.FollowCountDto(" +
             "   (SELECT COUNT(f1) FROM Follow f1 WHERE f1.following = :member), " +

--- a/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
+++ b/backend/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
@@ -1,10 +1,23 @@
 package kr.co.yigil.follow.domain.repository;
 
 import kr.co.yigil.follow.domain.Follow;
+import kr.co.yigil.follow.dto.FollowCountDto;
 import kr.co.yigil.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+
+    public int countAllByFollowing(Member member);
+    public int countAllByFollower(Member member);
+
+    @Query("SELECT new kr.co.yigil.follow.dto.FollowCountDto(" +
+            "   (SELECT COUNT(f1) FROM Follow f1 WHERE f1.following = :member), " +
+            "   (SELECT COUNT(f2) FROM Follow f2 WHERE f2.follower = :member)) " +
+            "FROM Follow f WHERE f.follower = :member OR f.following = :member")
+    FollowCountDto getFollowCounts(@Param("member") Member member);
 
     public void deleteByFollowerAndFollowing(Member Follower, Member Following);
 }

--- a/backend/src/main/java/kr/co/yigil/follow/dto/FollowCountDto.java
+++ b/backend/src/main/java/kr/co/yigil/follow/dto/FollowCountDto.java
@@ -1,0 +1,13 @@
+package kr.co.yigil.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowCountDto {
+    private int followerCount;
+    private int followingCount;
+}

--- a/backend/src/main/java/kr/co/yigil/global/config/JasyptConfig.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/JasyptConfig.java
@@ -1,5 +1,6 @@
 package kr.co.yigil.global.config;
 
+import lombok.Setter;
 import org.jasypt.encryption.StringEncryptor;
 import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.PropertySource;
 public class JasyptConfig {
 
     @Value("${Jasypt-Secret-Key}")
+    @Setter
     private String key;
 
     @Bean(name = "jasyptStringEncryptor")
@@ -22,7 +24,7 @@ public class JasyptConfig {
         return encryptor;
     }
 
-    private SimpleStringPBEConfig createSimpleStringPBEConfig() {
+    SimpleStringPBEConfig createSimpleStringPBEConfig() {
         SimpleStringPBEConfig config = new SimpleStringPBEConfig();
         setEncryptionConfigDetails(config, key);
         return config;

--- a/backend/src/main/java/kr/co/yigil/member/application/MemberService.java
+++ b/backend/src/main/java/kr/co/yigil/member/application/MemberService.java
@@ -3,14 +3,19 @@ package kr.co.yigil.member.application;
 import static kr.co.yigil.global.exception.ExceptionCode.NOT_FOUND_MEMBER_ID;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.yigil.file.FileUploadEvent;
 import kr.co.yigil.follow.application.FollowRedisIntegrityService;
+import kr.co.yigil.follow.domain.Follow;
 import kr.co.yigil.follow.domain.FollowCount;
+import kr.co.yigil.follow.domain.repository.FollowRepository;
 import kr.co.yigil.global.exception.BadRequestException;
 import kr.co.yigil.member.domain.Member;
 import kr.co.yigil.member.domain.repository.MemberRepository;
 import kr.co.yigil.member.dto.request.MemberUpdateRequest;
 import kr.co.yigil.member.dto.response.MemberDeleteResponse;
+import kr.co.yigil.member.dto.response.MemberFollowerListResponse;
+import kr.co.yigil.member.dto.response.MemberFollowingListResponse;
 import kr.co.yigil.member.dto.response.MemberInfoResponse;
 import kr.co.yigil.member.dto.response.MemberUpdateResponse;
 import kr.co.yigil.post.domain.Post;
@@ -26,6 +31,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final FollowRepository followRepository;
     private final FollowRedisIntegrityService followRedisIntegrityService;
     private final RedisTemplate<String, Object> redisTemplate;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -70,5 +76,19 @@ public class MemberService {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER_ID));
         memberRepository.delete(member);
         return new MemberDeleteResponse("회원 탈퇴 성공");
+    }
+
+    public MemberFollowerListResponse getFollowerList(final Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER_ID));
+        List<Member> followers = followRepository.findAllByFollowing(member)
+                .stream().map(Follow::getFollower).collect(Collectors.toList());
+        return new MemberFollowerListResponse(followers);
+    }
+
+    public MemberFollowingListResponse getFollowingList(final Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER_ID));
+        List<Member> followings = followRepository.findAllByFollower(member)
+                .stream().map(Follow::getFollowing).collect(Collectors.toList());
+        return new MemberFollowingListResponse(followings);
     }
 }

--- a/backend/src/main/java/kr/co/yigil/member/dto/response/MemberFollowerListResponse.java
+++ b/backend/src/main/java/kr/co/yigil/member/dto/response/MemberFollowerListResponse.java
@@ -1,0 +1,15 @@
+package kr.co.yigil.member.dto.response;
+
+import java.util.List;
+import kr.co.yigil.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberFollowerListResponse {
+
+    private List<Member> followerList;
+}

--- a/backend/src/main/java/kr/co/yigil/member/dto/response/MemberFollowingListResponse.java
+++ b/backend/src/main/java/kr/co/yigil/member/dto/response/MemberFollowingListResponse.java
@@ -1,0 +1,15 @@
+package kr.co.yigil.member.dto.response;
+
+import java.util.List;
+import kr.co.yigil.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberFollowingListResponse {
+
+    private List<Member> followingList;
+}

--- a/backend/src/main/java/kr/co/yigil/member/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/kr/co/yigil/member/dto/response/MemberInfoResponse.java
@@ -1,6 +1,7 @@
 package kr.co.yigil.member.dto.response;
 
 import java.util.List;
+import kr.co.yigil.follow.domain.FollowCount;
 import kr.co.yigil.member.domain.Member;
 import kr.co.yigil.post.domain.Post;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,13 @@ public class MemberInfoResponse {
 
     private List<Post> postList;
 
-    public static MemberInfoResponse from(final Member member, final List<Post> postList) {
-        return new MemberInfoResponse(member.getNickname(), member.getProfileImageUrl(), postList);
+    private int followerCount;
+
+    private int followingCount;
+
+    public static MemberInfoResponse from(final Member member, final List<Post> postList, final
+            FollowCount followCount) {
+        return new MemberInfoResponse(member.getNickname(), member.getProfileImageUrl(), postList, followCount.getFollowerCount(),
+                followCount.getFollowingCount());
     }
 }

--- a/backend/src/main/java/kr/co/yigil/member/presentation/MemberController.java
+++ b/backend/src/main/java/kr/co/yigil/member/presentation/MemberController.java
@@ -7,6 +7,8 @@ import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.member.application.MemberService;
 import kr.co.yigil.member.dto.request.MemberUpdateRequest;
 import kr.co.yigil.member.dto.response.MemberDeleteResponse;
+import kr.co.yigil.member.dto.response.MemberFollowerListResponse;
+import kr.co.yigil.member.dto.response.MemberFollowingListResponse;
 import kr.co.yigil.member.dto.response.MemberInfoResponse;
 import kr.co.yigil.member.dto.response.MemberUpdateResponse;
 import lombok.RequiredArgsConstructor;
@@ -54,5 +56,15 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/api/v1/member/follower/{memberId}")
+    public ResponseEntity<MemberFollowerListResponse> getMemberFollowerList(@PathVariable("memberId") final Long memberId) {
+        MemberFollowerListResponse response = memberService.getFollowerList(memberId);
+        return ResponseEntity.ok(response);
+    }
 
+    @GetMapping("/api/v1/member/following/{memberId}")
+    public ResponseEntity<MemberFollowingListResponse> getMemberFollowingList(@PathVariable("memberId") final Long memberId) {
+        MemberFollowingListResponse response = memberService.getFollowingList(memberId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/src/test/java/kr/co/yigil/follow/application/FollowRedisIntegrityServiceTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/application/FollowRedisIntegrityServiceTest.java
@@ -1,0 +1,70 @@
+package kr.co.yigil.follow.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import kr.co.yigil.follow.domain.FollowCount;
+import kr.co.yigil.follow.domain.repository.FollowRepository;
+import kr.co.yigil.follow.dto.FollowCountDto;
+import kr.co.yigil.member.domain.Member;
+import kr.co.yigil.member.domain.SocialLoginType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+public class FollowRedisIntegrityServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private FollowRedisIntegrityService followRedisIntegrityService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        followRedisIntegrityService = new FollowRedisIntegrityService(redisTemplate, followRepository);
+    }
+
+    @DisplayName("Redis에 FollowCount가 존재하지 않을 경우 DB에 조회 후 저장하는지")
+    @Test
+    void testEnsureFollowCountsWhenNotExist() {
+        Member member = new Member(1L, "email", "12345678", "member", "image.jpg", SocialLoginType.KAKAO);
+        FollowCountDto followCountDto = new FollowCountDto(10, 5);
+        FollowCount followCount = new FollowCount(1L, 10, 5);
+
+        when(redisTemplate.hasKey("followCount:1")).thenReturn(false);
+        when(followRepository.getFollowCounts(member)).thenReturn(followCountDto);
+
+        followRedisIntegrityService.ensureFollowCounts(member);
+
+        verify(valueOperations).set(eq("followCount:1"), any(FollowCount.class));
+    }
+
+    @DisplayName("Redis에 FollowCount가 존재할 경우 DB 조회 및 저장 로직이 실행되지 않는지")
+    @Test
+    void testEnsureFollowCountsWhenExists() {
+        Member member = new Member(1L, "email", "12345678", "member", "image.jpg", SocialLoginType.KAKAO);
+
+        when(redisTemplate.hasKey("followCount:1")).thenReturn(true);
+
+        followRedisIntegrityService.ensureFollowCounts(member);
+
+        verify(valueOperations, never()).set(anyString(), any());
+        verify(followRepository, never()).getFollowCounts(any(Member.class));
+    }
+}

--- a/backend/src/test/java/kr/co/yigil/follow/application/FollowServiceTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/application/FollowServiceTest.java
@@ -37,6 +37,9 @@ public class FollowServiceTest {
     @Mock
     private NotificationService notificationService;
 
+    @Mock
+    private FollowRedisIntegrityService followRedisIntegrityService;
+
     @InjectMocks
     private FollowService followService;
 

--- a/backend/src/test/java/kr/co/yigil/follow/domain/FollowCountTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/domain/FollowCountTest.java
@@ -1,0 +1,23 @@
+package kr.co.yigil.follow.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class FollowCountTest {
+
+    @DisplayName("FollowCount 엔티티가 잘 생성되고 접근 가능한지")
+    @Test
+    void createAndAccessFollowCount() {
+        Long memberId = 1L;
+        int followerCount = 10;
+        int followingCount = 6;
+        FollowCount followCount = new FollowCount(memberId, followerCount, followingCount);
+
+        assertEquals(memberId, followCount.getMemberId());
+        assertEquals(followerCount, followCount.getFollowerCount());
+        assertEquals(followingCount, followCount.getFollowingCount());
+    }
+
+}

--- a/backend/src/test/java/kr/co/yigil/follow/domain/FollowTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/domain/FollowTest.java
@@ -1,0 +1,26 @@
+package kr.co.yigil.follow.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import kr.co.yigil.member.domain.Member;
+import kr.co.yigil.member.domain.SocialLoginType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class FollowTest {
+
+    @DisplayName("팔로우 엔티티가 잘 생성되고 필드에 잘 접근되는지")
+    @Test
+    void createAndAccessFollow() {
+       Member follower = new Member(1L, "follower", "123456", "follower", "image.png", SocialLoginType.KAKAO);
+       Member following = new Member(2L, "following", "654321", "following", "profile.jpg", SocialLoginType.KAKAO);
+
+       Follow follow = new Follow(follower, following);
+
+       assertNotNull(follow);
+       assertEquals(follower, follow.getFollower());
+       assertEquals(following, follow.getFollowing());
+    }
+
+}

--- a/backend/src/test/java/kr/co/yigil/follow/domain/repository/FollowCountRedisRepositoryTest.java
+++ b/backend/src/test/java/kr/co/yigil/follow/domain/repository/FollowCountRedisRepositoryTest.java
@@ -1,0 +1,63 @@
+package kr.co.yigil.follow.domain.repository;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+public class FollowCountRedisRepositoryTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    private FollowCountRedisRepository followCountRedisRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        followCountRedisRepository = new FollowCountRedisRepository(redisTemplate);
+    }
+
+    @DisplayName("팔로워 수가 잘 증가하는지")
+    @Test
+    void incrementFollowersCountTest() {
+        Long memberId = 1L;
+        followCountRedisRepository.incrementFollowersCount(memberId);
+        verify(hashOperations, times(1)).increment("followCount", memberId + ":followerCount", 1);
+    }
+
+    @DisplayName("팔로워 수가 잘 감소하는지")
+    @Test
+    void decrementFollowersCountTest() {
+        Long memberId = 1L;
+        followCountRedisRepository.decrementFollowersCount(memberId);
+        verify(hashOperations, times(1)).increment("followCount", memberId + ":followerCount", -1);
+    }
+
+    @DisplayName("팔로잉 수가 잘 증가하는지")
+    @Test
+    void incrementFollowingsCountTest() {
+        Long memberId = 1L;
+        followCountRedisRepository.incrementFollowingsCount(memberId);
+        verify(hashOperations, times(1)).increment("followCount", memberId + ":followingCount", 1);
+    }
+
+    @DisplayName("팔로잉 수가 잘 감소하는지")
+    @Test
+    void decrementFollowingsCountTest() {
+        Long memberId = 1L;
+        followCountRedisRepository.decrementFollowingsCount(memberId);
+        verify(hashOperations, times(1)).increment("followCount", memberId + ":followingCount", -1);
+    }
+}

--- a/backend/src/test/java/kr/co/yigil/global/config/AsyncConfigTest.java
+++ b/backend/src/test/java/kr/co/yigil/global/config/AsyncConfigTest.java
@@ -1,0 +1,38 @@
+package kr.co.yigil.global.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import kr.co.yigil.global.exception.AsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskExecutor;
+
+public class AsyncConfigTest {
+
+    private final AsyncConfig asyncConfig = new AsyncConfig();
+
+    @DisplayName("TaskExecutor가 잘 구성되었는지")
+    @Test
+    void taskExecutorConfiguration() {
+        TaskExecutor taskExecutor = asyncConfig.taskExecutor();
+
+        assertInstanceOf(ThreadPoolTaskExecutor.class, taskExecutor);
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = (ThreadPoolTaskExecutor) taskExecutor;
+
+        assertEquals(0, threadPoolTaskExecutor.getCorePoolSize());
+        assertEquals("async-task", threadPoolTaskExecutor.getThreadNamePrefix());
+    }
+
+    @DisplayName("AsyncUncaughtExceptionHandler가 잘 구성되었는지")
+    @Test
+    void asyncExceptionHandlerConfiguration() {
+        AsyncUncaughtExceptionHandler handler = asyncConfig.getAsyncUncaughtExceptionHandler();
+
+        assertInstanceOf(AsyncExceptionHandler.class, handler);
+    }
+
+}

--- a/backend/src/test/java/kr/co/yigil/global/config/JasyptConfigTest.java
+++ b/backend/src/test/java/kr/co/yigil/global/config/JasyptConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import kr.co.yigil.login.application.strategy.KakaoLoginStrategy;
 import org.jasypt.encryption.StringEncryptor;
 import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
@@ -14,7 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
+@SpringBootTest(classes = JasyptConfig.class)
 @TestPropertySource(locations = "classpath:config.properties")
 public class JasyptConfigTest {
 

--- a/backend/src/test/java/kr/co/yigil/global/config/JasyptConfigTest.java
+++ b/backend/src/test/java/kr/co/yigil/global/config/JasyptConfigTest.java
@@ -1,0 +1,49 @@
+package kr.co.yigil.global.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:config.properties")
+public class JasyptConfigTest {
+
+    @Value("${Jasypt-Secret-Key}")
+    private String key;
+
+    private final JasyptConfig jasyptConfig = new JasyptConfig();
+
+    @DisplayName("StringEncryptor의 빈이 잘 등록되는지")
+    @Test
+    void testStringEncryptorAsBean() {
+        jasyptConfig.setKey(key);
+        StringEncryptor encryptor = jasyptConfig.stringEncryptor();
+
+        assertNotNull(encryptor);
+        assertInstanceOf(PooledPBEStringEncryptor.class, encryptor);
+        PooledPBEStringEncryptor pooledPBEStringEncryptor= (PooledPBEStringEncryptor) encryptor;
+        assertNotNull(pooledPBEStringEncryptor);
+    }
+
+    @DisplayName("SimpleStringPBEConfig가 잘 구성되는지")
+    @Test
+    void testSimpleStringPBEConfig() {
+        SimpleStringPBEConfig config = jasyptConfig.createSimpleStringPBEConfig();
+
+        assertEquals("PBEWithMD5AndDES", config.getAlgorithm());
+        assertEquals(1000, config.getKeyObtentionIterations());
+        assertEquals(1, config.getPoolSize());
+        assertEquals("SunJCE", config.getProviderName());
+        assertEquals("base64", config.getStringOutputType());
+    }
+}

--- a/backend/src/test/java/kr/co/yigil/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/kr/co/yigil/member/application/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import kr.co.yigil.file.FileUploadEvent;
+import kr.co.yigil.follow.domain.FollowCount;
 import kr.co.yigil.global.exception.BadRequestException;
 import kr.co.yigil.member.domain.Member;
 import kr.co.yigil.member.domain.SocialLoginType;
@@ -29,8 +31,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 
 public class MemberServiceTest {
 
@@ -42,6 +45,9 @@ public class MemberServiceTest {
 
     @InjectMocks
     private MemberService memberService;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -57,9 +63,13 @@ public class MemberServiceTest {
         Long memberId = 1L;
         Member mockMember = new Member("kiit0901@gmail.com", "123456", "stone", "profile.jpg", "kakao");
         List<Post> mockPostList = new ArrayList<>();
+        FollowCount mockFollowCount = new FollowCount(1L, 0, 0);
+        ValueOperations<String, Object> valueOperationsMock = mock(ValueOperations.class);
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
         when(postRepository.findAllByMember(mockMember)).thenReturn(mockPostList);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperationsMock);
+        when(valueOperationsMock.get(anyString())).thenReturn(mockFollowCount);
 
         MemberInfoResponse response = memberService.getMemberInfo(memberId);
 

--- a/backend/src/test/java/kr/co/yigil/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/kr/co/yigil/member/presentation/MemberControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
+import java.util.Queue;
 import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.member.application.MemberService;
 import kr.co.yigil.member.dto.request.MemberUpdateRequest;

--- a/backend/src/test/java/kr/co/yigil/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/kr/co/yigil/member/presentation/MemberControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-import java.util.Queue;
 import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.member.application.MemberService;
 import kr.co.yigil.member.dto.request.MemberUpdateRequest;
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;


### PR DESCRIPTION
## Motivation 🧐

- 팔로우 팔로워 리스트 조회를 위한 api를 만들었습니다 그리고 캐시 데이터베이스와 RDBMS 사이의 데이터 동기화 전략을 작성하였습니다.

<br>

## Key Changes 🔑

- 팔로워 팔로잉 리스트 api 개설
- 레디스 동기화를 위한 서비스 레이어 (클래스) 추가
- 비즈니스로직 검증을 위한 테스트 작성
<br>

## To Reviewers 🙏
- 컨트롤러 테스트는 내일 수정하겠읍니다...
- api 명세서는 내일 작성하겠읍니다.
- 아~쌒으로 부탁드립니다.