### PR TITLE
chore: add configuration for db replication

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,7 +41,6 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.hibernate:hibernate-core:6.4.0.Final'

--- a/backend/docker/postgreSQL/Dockerfile
+++ b/backend/docker/postgreSQL/Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres:latest
+RUN apt-get update && apt-get install -y postgis postgresql-16-postgis-3

--- a/backend/docker/postgreSQL/docker-compose.yml
+++ b/backend/docker/postgreSQL/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  postgres-master:
+    build: .
+    ports:
+      - "5432:5432"
+  postgres-slave:
+    build: .
+    ports:
+      - "5433:5432"

--- a/backend/src/main/java/kr/co/yigil/follow/dto/response/FollowResponse.java
+++ b/backend/src/main/java/kr/co/yigil/follow/dto/response/FollowResponse.java
@@ -8,6 +8,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FollowResponse {
-
     private String message;
 }

--- a/backend/src/main/java/kr/co/yigil/global/config/datasource/DataSourceType.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/datasource/DataSourceType.java
@@ -1,0 +1,5 @@
+package kr.co.yigil.global.config.datasource;
+
+public enum DataSourceType {
+    Master, Slave
+}

--- a/backend/src/main/java/kr/co/yigil/global/config/datasource/MasterDataSourceConfig.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/datasource/MasterDataSourceConfig.java
@@ -1,0 +1,22 @@
+package kr.co.yigil.global.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class MasterDataSourceConfig {
+
+    @Primary
+    @Bean(name = "masterDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.master.hikari")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/global/config/datasource/SlaveDataSourceConfig.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/datasource/SlaveDataSourceConfig.java
@@ -1,0 +1,20 @@
+package kr.co.yigil.global.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlaveDataSourceConfig {
+
+    @Bean(name= "slaveDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.slave.hikari")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/global/config/replication/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/replication/ReplicationRoutingDataSource.java
@@ -1,0 +1,14 @@
+package kr.co.yigil.global.config.replication;
+
+import kr.co.yigil.global.config.datasource.DataSourceType;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly() ?
+                DataSourceType.Slave : DataSourceType.Master;
+    }
+}

--- a/backend/src/main/java/kr/co/yigil/global/config/replication/RoutingDataSourceConfig.java
+++ b/backend/src/main/java/kr/co/yigil/global/config/replication/RoutingDataSourceConfig.java
@@ -1,0 +1,34 @@
+package kr.co.yigil.global.config.replication;
+
+import java.util.Map;
+import javax.sql.DataSource;
+import kr.co.yigil.global.config.datasource.DataSourceType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class RoutingDataSourceConfig {
+
+    @Bean(name= "routingDataSource")
+    public DataSource routingDataSource(@Qualifier("masterDataSource") DataSource masterDataSource,
+                                        @Qualifier("slaveDataSource") DataSource slaveDataSource) {
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = Map.of(
+                DataSourceType.Master, masterDataSource,
+                DataSourceType.Slave, slaveDataSource
+        );
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean(name = "dataSource")
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}


### PR DESCRIPTION
## Motivation 🧐
- db 레플리케이션 구조를 적용하기 위해 설정 파일을 적용합니다.

<br>

## Key Changes 🔑
- global/config 내의 설정 파일 생성 및 수정 (datasource, replication)
- application.yml 파일 구조 변경
<br>

## To Reviewers 🙏
- 해당 설정 적용 및 로컬에서도 db replication 을 성공 및 적용하셨다면 프로젝트는 잘 실행됩니다. (배포 서버의 설정을 변경해야 합니다.)
- @Transactional(readonly="true")설정이 있는 Service에서는 transaction 설정을 판별하여, Slave 로 요청을 보내게 됩니다 (읽기 전용)
- 해당 설정 방법은 위키에 작성해서 남겨놓겠습니다 :)
