### PR TITLE
Login 페이지 스타일 수정

### DIFF
--- a/frontend/src/app/(without-header)/login/page.tsx
+++ b/frontend/src/app/(without-header)/login/page.tsx
@@ -7,23 +7,25 @@ import CloseButton from '@/app/_components/ui/button/CloseButton';
 
 export default function LoginPage() {
   return (
-    <div className="w-full h-screen bg-main flex flex-col items-center">
+    <div className="w-full h-full bg-main flex flex-col items-center">
       <CloseButton
-        containerStyle="mt-5 mr-6 self-end"
-        style="w-12 h-12 stroke-2 stroke-black hover:stroke-gray-700 active:stroke-gray-500"
+        containerStyle="w-full flex justify-end h-1/6 mr-6 mt-5"
+        style="cursor-pointer w-12 h-12 stroke-2 stroke-black hover:stroke-gray-700 active:stroke-gray-500"
       />
-      <div className="mt-[116px] mb-[202px]">
+      <div className="h-2/6">
         <LoginLogo className="w-[290px] h-[96px]" />
       </div>
-      <div className="w-full flex gap-x-4 px-8 mx-7 relative">
-        <div className="border-t-[1px] border-white w-full h-1"></div>
-        <div className="absolute top-[-12px] left-1/2 -translate-x-1/2 px-2 text-xl text-white bg-main">
-          SNS로 간편로그인
+      <div className="w-full mx-7 h-2/6">
+        <div className="w-full flex gap-x-4 px-8  relative ">
+          <div className="border-t-[1px] border-white w-full h-1"></div>
+          <div className="absolute top-[-12px] left-1/2 -translate-x-1/2 px-2 text-xl text-white bg-main">
+            SNS로 간편로그인
+          </div>
         </div>
-      </div>
-      <div className="w-full mt-10 px-7 flex flex-col items-center justify-center gap-4">
-        <KakaoBtn />
-        <GoogleLoginButton />
+        <div className="w-full mt-10 px-7 flex flex-col items-center justify-center gap-4">
+          <KakaoBtn />
+          <GoogleLoginButton />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/_components/ui/button/CloseButton.tsx
+++ b/frontend/src/app/_components/ui/button/CloseButton.tsx
@@ -2,7 +2,6 @@
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import XLogo from '/public/icons/x.svg';
-
 interface TButtonProps {
   containerStyle?: string;
   style?: string;
@@ -10,13 +9,10 @@ interface TButtonProps {
 
 export default function CloseButton({ containerStyle, style }: TButtonProps) {
   const router = useRouter();
+
   return (
-    <div
-      className={`${containerStyle}`}
-      onClick={() => router.back()}
-      tabIndex={0}
-    >
-      <XLogo className={`cursor-pointer ${style}`} />
-    </div>
+    <button className={containerStyle} onClick={() => router.back()}>
+      <XLogo className={style} />
+    </button>
   );
 }


### PR DESCRIPTION
## Motivation 🧐
로고의 마진 속성을 픽셀로 지정했을 때 높이가 낮은 디바이스일 경우 로그인 버튼 뒷 배경이 제거되는 문제가 발생할 수 있어 스타일을 수정했습니다.
<br>

## Key Changes 🔑
마진 속성이 아닌 로고와 로그인 버튼 등 각 태그의 높이 속성을 비율로 지정했습니다.
<br>

## To Reviewers 🙏
`CloseButton` 컴포넌트를 원래 제거하려고 했었으나 login의 page 자체는 서버 컴포넌트로 사용 중이기 때문에 따로 컴포넌트를 분리해 사용했습니다.