### PR TITLE
안내 문구 컴포넌트 구현

### DIFF
--- a/frontend/src/app/_components/add/common/InfoTitle.tsx
+++ b/frontend/src/app/_components/add/common/InfoTitle.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface TInfoTitle {
+  label: string;
+  additionalLabel: string;
+  textSizeAndLineHeight?: string;
+  fontBold?: string;
+  height?: string;
+}
+
+export default function InfoTitle({
+  label,
+  additionalLabel,
+  textSizeAndLineHeight,
+  fontBold,
+  height,
+}: TInfoTitle) {
+  return (
+    <div
+      className={`flex flex-col justify-center pl-8 ${
+        textSizeAndLineHeight ? textSizeAndLineHeight : 'text-[32px] leading-10'
+      } ${fontBold ? fontBold : 'font-semibold'} ${height ? height : ' h-1/3'}`}
+    >
+      <span className="text-blue-400">
+        {label}
+        <span className="text-black">{additionalLabel.slice(0, 1)}</span>
+      </span>
+      <span className="text-black">
+        {additionalLabel.slice(1, additionalLabel.length)}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Motivation 🧐
- #212 이슈에 따라 안내 문구 컴포넌트를 구현했습니다.
- props로 색상이 변경 될 `label`, 나머지 부가 글인 `addtionalLabel`, 글자 사이즈와 `line-height`을 설정하는 `textSizeAndLineHeight`, 폰트 굵기 설정하는 `fontBold`, 컴포넌트의 높이를 결정할 `height` 를 받습니다.

## Key Changes 🔑


## To Reviewers 🙏
색상이 다른 글자와 검정 글자 부분이 첫 번째 줄에 함께 포함되어 있어 [slice](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/String/slice) 메서드를 사용했는데 좋은 방법인지 모르겠습니다. 혹시 생각하셨던 좋은 방법이 있을까요?☺️