### PR TITLE
백엔드 리팩토링 과정에서 유실된 코드 복원

### DIFF
--- a/frontend/src/app/_components/post/Post.tsx
+++ b/frontend/src/app/_components/post/Post.tsx
@@ -4,7 +4,7 @@ import CommentIcon from '/public/icons/comment.svg';
 import HeartIcon from '/public/icons/heart.svg';
 import StarIcon from '/public/icons/star.svg';
 
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactElement } from 'react';
 
 type TRegion =
   | '강원'
@@ -29,11 +29,11 @@ export interface TPost {
 }
 
 function IconWithCounts({
-  Icon,
+  icon,
   count,
   rating,
 }: {
-  Icon: ComponentType<{ className?: string }>;
+  icon: ReactElement;
   count: number;
   rating?: boolean;
 }) {
@@ -41,7 +41,7 @@ function IconWithCounts({
 
   return (
     <div className="flex items-center">
-      <Icon className="w-4 h-4" />
+      {icon}
       <p className="pl-1 flex justify-center">{label}</p>
     </div>
   );
@@ -72,9 +72,21 @@ export default function Post({
       <section className="flex justify-between items-center gap-2 px-4">
         <p className="text-xl truncate">{title}</p>
         <div className="flex gap-2">
-          <IconWithCounts Icon={CommentIcon} count={commentCount} />
-          <IconWithCounts Icon={HeartIcon} count={likeCount} />
-          <IconWithCounts Icon={StarIcon} count={rating} rating />
+          <IconWithCounts
+            icon={<CommentIcon className="w-4 h-4" />}
+            count={commentCount}
+          />
+          <IconWithCounts
+            icon={<HeartIcon className="w-4 h-4" />}
+            count={likeCount}
+          />
+          <IconWithCounts
+            icon={
+              <StarIcon className="w-4 h-4 fill-[#FACC15] stroke-[#FACC15]" />
+            }
+            count={rating}
+            rating
+          />
         </div>
       </section>
     </article>

--- a/frontend/src/app/_components/post/PostList.tsx
+++ b/frontend/src/app/_components/post/PostList.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import useEmblaCarousel from 'embla-carousel-react';
+
+import { Post } from '@/app/_components/post';
+
+import type { TPost } from './Post';
+import Link from 'next/link';
+
+export default function PostList({
+  title,
+  data,
+}: {
+  title: string;
+  data: TPost[];
+}) {
+  const [emblaRef] = useEmblaCarousel({
+    loop: false,
+    dragFree: true,
+  });
+  return (
+    <section className="flex flex-col" aria-label="posts">
+      <div className="flex justify-between px-8">
+        <span className="text-2xl">{title}</span>
+        <span className="self-center">더보기</span>
+      </div>
+      <div className="overflow-hidden px-4" ref={emblaRef}>
+        <div className="flex">
+          {data.map((post) => (
+            <Link href={`#`} key={post.id}>
+              <Post {...post} />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Motivation 🧐
#216 PR에서 유실된 코드를 복원합니다.
추가로, Icon 렌더링 책임을 부모 컴포넌트가 가지도록 구조를 수정합니다.

## Key Changes 🔑
- 사라졌던 `PostList` 컴포넌트 코드를 복원했습니다.
- Icon을 부모 컴포넌트에서 렌더링한 후, `ReactElement` 타입의 prop으로 내려주어 Icon별로 스타일을 지정할 수 있도록 변경하였습니다.

## To Reviewers 🙏
백엔드 PR 과정에서 유실된 코드가 있기 때문에, 해당 PR의 작업자인 @Uknow928 님을 리뷰어로 추가합니다. 해당 파일이 맞는지 여부만 확인해주시면 됩니다. @davidktlee 님께서는 refactor된 코드에 대해서 함께 확인해주시면 좋겠습니다.