### PR TITLE
FAB 구조 변경 및 pop over data icon 타입 변경

### DIFF
--- a/frontend/public/icons/trash.svg
+++ b/frontend/public/icons/trash.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.5 7H6.16667H19.5" stroke="black" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.8327 7.00001V18.6667C17.8327 19.1087 17.6571 19.5326 17.3445 19.8452C17.032 20.1577 16.608 20.3333 16.166 20.3333H7.83268C7.39065 20.3333 6.96673 20.1577 6.65417 19.8452C6.34161 19.5326 6.16602 19.1087 6.16602 18.6667V7.00001M8.66602 7.00001V5.33334C8.66602 4.89131 8.84161 4.46739 9.15417 4.15483C9.46673 3.84227 9.89065 3.66667 10.3327 3.66667H13.666C14.108 3.66667 14.532 3.84227 14.8445 4.15483C15.1571 4.46739 15.3327 4.89131 15.3327 5.33334V7.00001" stroke="black" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.334 11.1667V16.1667" stroke="black" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.666 11.1667V16.1667" stroke="black" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/app/(with-header)/(home)/page.tsx
+++ b/frontend/src/app/(with-header)/(home)/page.tsx
@@ -1,14 +1,14 @@
 import FloatingActionButton from '@/app/_components/FloatingActionButton';
 import { PostList } from '@/app/_components/post';
-
 import { postData } from '@/app/_components/post/constants';
+import { fabpopOverData } from '@/app/_components/ui/popover/constants';
 
 export default async function HomePage() {
   return (
     <main className="max-w-full flex flex-col gap-8 relative">
       <PostList title="인기 장소" data={postData} />
       <PostList title="관심 지역 장소" data={postData} />
-      <FloatingActionButton />
+      <FloatingActionButton popOverData={fabpopOverData} />
     </main>
   );
 }

--- a/frontend/src/app/(with-header)/(home)/page.tsx
+++ b/frontend/src/app/(with-header)/(home)/page.tsx
@@ -8,7 +8,10 @@ export default async function HomePage() {
     <main className="max-w-full flex flex-col gap-8 relative">
       <PostList title="인기 장소" data={postData} />
       <PostList title="관심 지역 장소" data={postData} />
-      <FloatingActionButton popOverData={homePopOverData} />
+      <FloatingActionButton
+        popOverData={homePopOverData}
+        backdropStyle="bg-black bg-opacity-10"
+      />
     </main>
   );
 }

--- a/frontend/src/app/(with-header)/(home)/page.tsx
+++ b/frontend/src/app/(with-header)/(home)/page.tsx
@@ -1,14 +1,14 @@
 import FloatingActionButton from '@/app/_components/FloatingActionButton';
 import { PostList } from '@/app/_components/post';
 import { postData } from '@/app/_components/post/constants';
-import { fabpopOverData } from '@/app/_components/ui/popover/constants';
+import { homePopOverData } from '@/app/_components/ui/popover/constants';
 
 export default async function HomePage() {
   return (
     <main className="max-w-full flex flex-col gap-8 relative">
       <PostList title="인기 장소" data={postData} />
       <PostList title="관심 지역 장소" data={postData} />
-      <FloatingActionButton popOverData={fabpopOverData} />
+      <FloatingActionButton popOverData={homePopOverData} />
     </main>
   );
 }

--- a/frontend/src/app/_components/FloatingActionButton.tsx
+++ b/frontend/src/app/_components/FloatingActionButton.tsx
@@ -1,10 +1,16 @@
 'use client';
 import PlusIcon from '@/../public/icons/plus.svg';
 import { useState } from 'react';
-import { fabpopOverData } from './ui/popover/constants';
 import PopOver from './ui/popover/PopOver';
+import { TPopOverData } from './ui/popover/types';
 
-export default function FloatingActionButton() {
+interface TFloatingActionButton {
+  popOverData: TPopOverData[];
+}
+
+export default function FloatingActionButton({
+  popOverData,
+}: TFloatingActionButton) {
   const [isModalOpened, setIsModalOpened] = useState(false);
 
   const closeModal = () => {
@@ -28,7 +34,7 @@ export default function FloatingActionButton() {
         />
         {isModalOpened && (
           <PopOver
-            popOverData={fabpopOverData}
+            popOverData={popOverData}
             closeModal={closeModal}
             position="bottom-[160px] right-10"
             backdropStyle="bg-black bg-opacity-10"

--- a/frontend/src/app/_components/FloatingActionButton.tsx
+++ b/frontend/src/app/_components/FloatingActionButton.tsx
@@ -6,10 +6,12 @@ import { TPopOverData } from './ui/popover/types';
 
 interface TFloatingActionButton {
   popOverData: TPopOverData[];
+  backdropStyle?: string;
 }
 
 export default function FloatingActionButton({
   popOverData,
+  backdropStyle,
 }: TFloatingActionButton) {
   const [isModalOpened, setIsModalOpened] = useState(false);
 
@@ -37,7 +39,7 @@ export default function FloatingActionButton({
             popOverData={popOverData}
             closeModal={closeModal}
             position="bottom-[160px] right-10"
-            backdropStyle="bg-black bg-opacity-10"
+            backdropStyle={backdropStyle}
           />
         )}
       </button>

--- a/frontend/src/app/_components/ui/popover/PopOverItem.tsx
+++ b/frontend/src/app/_components/ui/popover/PopOverItem.tsx
@@ -9,7 +9,7 @@ interface TPopOverIcon {
 
 export default function PopOverIcon({ data, closeModal }: TPopOverIcon) {
   const { push } = useRouter();
-  const { href, onClick, label, Icon } = data;
+  const { href, onClick, label, icon } = data;
   return (
     <div
       onClick={() => {
@@ -20,7 +20,7 @@ export default function PopOverIcon({ data, closeModal }: TPopOverIcon) {
       className="flex items-center gap-x-2 cursor-pointer"
     >
       <div>{label}</div>
-      <Icon className="w-6 h-6" />
+      {icon}
     </div>
   );
 }

--- a/frontend/src/app/_components/ui/popover/constants.tsx
+++ b/frontend/src/app/_components/ui/popover/constants.tsx
@@ -4,22 +4,42 @@ import { signOut } from 'next-auth/react';
 import { TPopOverData } from './types';
 import LocationIcon from '/public/icons/location.svg';
 import CalendarIcon from '/public/icons/calendar.svg';
+import UnLockIcon from '/public/icons/unlock.svg';
+import TrashIcon from '/public/icons/trash.svg';
 
 export const headerPopOverData: TPopOverData[] = [
   {
     href: '/mypage',
     label: '마이페이지',
-    Icon: MapPin,
+    icon: <MapPin className="w-6 h-6" />,
   },
   {
     href: '/',
     label: '로그아웃',
-    Icon: Bell,
+    icon: <Bell className="w-6 h-6" />,
     onClick: () => signOut(),
   },
 ];
 
-export const fabpopOverData: TPopOverData[] = [
-  { href: '/add/spot', label: '장소 추가하기', Icon: LocationIcon },
-  { href: '/add/course', label: '일정 추가하기', Icon: CalendarIcon },
+export const homePopOverData: TPopOverData[] = [
+  {
+    href: '/add/spot',
+    label: '장소 추가하기',
+    icon: <LocationIcon className="w-6 h-6" />,
+  },
+  {
+    href: '/add/course',
+    label: '일정 추가하기',
+    icon: <CalendarIcon className="w-6 h-6" />,
+  },
+];
+
+export const myPagePopOverData: TPopOverData[] = [
+  { label: '나만보기 풀기', icon: <UnLockIcon className="w-6 h-6" /> },
+  { label: '기록 삭제하기', icon: <TrashIcon classname="w-6 h-6" /> },
+  {
+    href: '/add/course',
+    label: '일정 기록하기',
+    icon: <CalendarIcon className="w-6 h-6" />,
+  },
 ];

--- a/frontend/src/app/_components/ui/popover/types.ts
+++ b/frontend/src/app/_components/ui/popover/types.ts
@@ -1,8 +1,8 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactElement } from 'react';
 
 export interface TPopOverData {
   href?: string;
   label: string;
-  Icon: ComponentType<{ className?: string }>;
+  icon: ReactElement
   onClick?: () => void;
 }


### PR DESCRIPTION
## Motivation 🧐
`FAB`가 범용 컴포넌트로써 동작하게 하기 위해 `FAB`에 들어가는 pop over data를 상위 컴포넌트에서 전달하는 방식으로 구조를 변경했습니다.

<br>

## Key Changes 🔑
`FAB`를 여러 곳에서 호출, 사용하기 위해 pop over data를 props로 전달하는 방식으로 변경했습니다.
pop over icon의 스타일이 정해져있던 코드였는데 각 데이터를 전달할 때 스타일을 정의할 수 있게 코드 구조를 변경했습니다.
<br>

## To Reviewers 🙏
디자인이 자주 변경됨에 따라 코드가 자주 바뀌는 상황이긴 하지만 좀 더 범용성 높은 컴포넌트로 설계해 수정 공수 및 리뷰 공수가 적게 들게 노력해보겠습니다.