### PR TITLE
api 요청 로직 작성

### DIFF
--- a/frontend/src/app/_components/api/httpRequest.ts
+++ b/frontend/src/app/_components/api/httpRequest.ts
@@ -1,0 +1,35 @@
+const BASE_URL =
+  typeof window !== 'undefined'
+    ? process.env.NEXT_PUBLIC_BASE_URL
+    : process.env.BASE_URL;
+
+const headerInitOption = { 'content-type': 'application/json' };
+export const httpRequest =
+  (url: string) =>
+  (params: string = '') =>
+  (method: string = 'GET', body: any = null) =>
+  (headers: {} = headerInitOption) =>
+  async (errorMsg: string = '요청에 실패했습니다') => {
+    try {
+      const res = await fetch(`${BASE_URL}/v1/${url}${params}`, {
+        method,
+        headers,
+        ...(body && { body: JSON.stringify(body) }),
+      });
+
+      if (res.ok) {
+        const result = await res.json();
+        return result;
+      }
+    } catch (error) {
+      // error 컴포넌트나 토스트 정의 시 사용할 부분
+      console.log(error); // 디버그 용
+      console.error(errorMsg);
+    }
+  };
+
+/**
+ *  const spotsRequest = httpRequest('spots');
+ *  const getSpot = spotsRequest('/1');
+ *  const res = await getSpot()()('요청이 실패했습니다.');
+ */

--- a/frontend/src/app/_components/api/httpRequest.ts
+++ b/frontend/src/app/_components/api/httpRequest.ts
@@ -3,7 +3,7 @@ const BASE_URL =
     ? process.env.NEXT_PUBLIC_BASE_URL
     : process.env.BASE_URL;
 
-const headerInitOption = { 'content-type': 'application/json' };
+const headerInitOption = { 'Content-Type': 'application/json' };
 export const httpRequest =
   (url: string) =>
   (params: string = '') =>

--- a/frontend/src/app/endpoints/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/endpoints/api/auth/[...nextauth]/route.ts
@@ -21,7 +21,7 @@ const handler = NextAuth({
         nickname: user.name,
         provider: account?.provider,
       });
-      const res = await fetch(`${process.env.BASE_URL}/login`, {
+      const res = await fetch(`${process.env.BASE_URL}/v1/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Motivation 🧐
#235 이슈에서 언급했던 fetch 함수를 커링을 이용해 작성했습니다.
api 요청 함수를 사용하기 위해서는 여러 파라미터를 한 번에 받아야 하는 상황이 많은데,
커링 함수를 이용해 관심사 별로 분리가 가능하게 됨으로써 비슷한 로직을 가진 함수 임에도 매 번 많은 파라미터를 전달하지 않아도 되는 장점이 있습니다.

#205 현재는 환경 변수의 `base url`에 v1이라는 버전까지 명시가 되어 있는데 버전은 바뀔 가능성이 높으므로 환경 변수로 관리하지 않고 직접 작성하는 방식으로 바꿨습니다.
<br>

## Key Changes 🔑

<br>

## To Reviewers 🙏
`next-auth`의 로그인 로직에서는 커링 함수로 작성한 fetch 로직이 잘 작동하지 않아 기존의 로직을 사용하는 것으로 해두었습니다.