### PR TITLE
Member 도메인 수정 및 Follow Service 수정

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/repository/SpotRepository.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/repository/SpotRepository.java
@@ -1,9 +1,10 @@
 package kr.co.yigil.travel.repository;
 
-import java.util.List;
+
 import java.util.Optional;
 import kr.co.yigil.member.Member;
 import kr.co.yigil.travel.Spot;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,7 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
 
     @Query("SELECT s FROM Spot s WHERE s.place.id = :placeId AND s.isInCourse = false")
     Slice<Spot> findAllByPlaceIdAndIsInCourseFalse(@Param("placeId") Long placeId, Pageable pageable);
+
+    @Query("SELECT s FROM Spot s WHERE s.member.id = :memberId AND s.isInCourse = false")
+    Slice<Spot> findAllByMemberAndIsInCourseFalse(Long memberId, Pageable pageable);
 }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/follow/application/FollowService.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/follow/application/FollowService.java
@@ -8,6 +8,7 @@ import kr.co.yigil.follow.dto.response.FollowResponse;
 import kr.co.yigil.follow.dto.response.UnfollowResponse;
 import kr.co.yigil.global.exception.BadRequestException;
 import kr.co.yigil.global.exception.ExceptionCode;
+import kr.co.yigil.global.exception.ExceptionResponse;
 import kr.co.yigil.member.Member;
 import kr.co.yigil.member.repository.MemberRepository;
 import kr.co.yigil.notification.application.NotificationService;
@@ -27,6 +28,11 @@ public class FollowService {
 
     @Transactional
     public FollowResponse follow(final Long followerId, final Long followingId) {
+        if (followerId.equals(followingId)) {
+            return new FollowResponse("나 자신을 follow할 수 없습니다.");
+        } else if (followRepository.existsByFollowerIdAndFollowingId(followerId, followingId)) {
+            return new FollowResponse("이미 follow 처리 되어 있습니다.");
+        }
         Member follower = getMemberById(followerId);
         Member following = getMemberById(followingId);
 

--- a/backend/yigil-api/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/follow/domain/repository/FollowRepository.java
@@ -4,19 +4,21 @@ import java.util.List;
 import kr.co.yigil.follow.domain.Follow;
 import kr.co.yigil.follow.dto.FollowCountDto;
 import kr.co.yigil.member.Member;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+    public boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
-    public List<Follow> findAllByFollowing(Member member);
+    public Slice<Follow> findAllByFollowing(Member member);
 
-    public List<Follow> findAllByFollower(Member member);
+    public Slice<Follow> findAllByFollower(Member member);
 
     @Query("SELECT new kr.co.yigil.follow.dto.FollowCountDto(" +
-            "   (SELECT COUNT(f1) FROM Follow f1 WHERE f1.following = :member), " +
-            "   (SELECT COUNT(f2) FROM Follow f2 WHERE f2.follower = :member))")
+        "   (SELECT COUNT(f1) FROM Follow f1 WHERE f1.following = :member), " +
+        "   (SELECT COUNT(f2) FROM Follow f2 WHERE f2.follower = :member))")
     FollowCountDto getFollowCounts(@Param("member") Member member);
 
     public void deleteByFollowerAndFollowing(Member Follower, Member Following);

--- a/backend/yigil-api/src/main/java/kr/co/yigil/follow/dto/response/FollowerFindDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/follow/dto/response/FollowerFindDto.java
@@ -1,0 +1,23 @@
+package kr.co.yigil.follow.dto.response;
+
+import kr.co.yigil.follow.domain.Follow;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowerFindDto {
+    private String memberImageUrl;
+    private String memberNickName;
+    private Long followingId;
+
+    public static FollowerFindDto from(Follow follow) {
+        return new FollowerFindDto(
+                follow.getFollowing().getProfileImageUrl(),
+                follow.getFollowing().getNickname(),
+                follow.getFollowing().getId()
+        );
+    }
+}

--- a/backend/yigil-api/src/main/java/kr/co/yigil/follow/dto/response/FollowingFindDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/follow/dto/response/FollowingFindDto.java
@@ -1,0 +1,22 @@
+package kr.co.yigil.follow.dto.response;
+
+import kr.co.yigil.follow.domain.Follow;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowingFindDto {
+        private String memberImageUrl;
+        private String memberNickName;
+        private Long followingId;
+
+        public static FollowingFindDto from(Follow follow) {
+            return new FollowingFindDto(
+                follow.getFollowing().getProfileImageUrl(),
+                follow.getFollowing().getNickname(),
+                follow.getFollowing().getId()
+            );
+        }
+}

--- a/backend/yigil-api/src/main/java/kr/co/yigil/global/config/SecurityConfig.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/global/config/SecurityConfig.java
@@ -1,18 +1,14 @@
 package kr.co.yigil.global.config;
 
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -22,25 +18,20 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .cors(Customizer.withDefaults())
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests((authorizeRequests) -> authorizeRequests.anyRequest().permitAll())
-                .securityContext(AbstractHttpConfigurer::disable)
-                .sessionManagement((sessionManagement) -> sessionManagement.maximumSessions(1));
+            .cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
+                CorsConfiguration config = new CorsConfiguration();
+                config.setAllowedOrigins(List.of("http://localhost:3000", "https://yigil.co.kr"));
+                config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+                config.setAllowedHeaders(List.of("*"));
+                config.setAllowCredentials(true);
+                config.setMaxAge(3600L);
+                return config;
+            }))
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests((authorizeRequests) -> authorizeRequests.anyRequest().permitAll())
+            .securityContext(AbstractHttpConfigurer::disable)
+            .sessionManagement((sessionManagement) -> sessionManagement.maximumSessions(1));
         return http.build();
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowCredentials(true);
-        configuration.setAllowedOriginPatterns(List.of("https://yigil.co.kr"));
-        configuration.addAllowedMethod(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS").toString());
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 적용
-        return source;
     }
 
 }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/presentation/MemberController.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/presentation/MemberController.java
@@ -4,22 +4,28 @@ import jakarta.servlet.http.HttpServletRequest;
 import kr.co.yigil.auth.Auth;
 import kr.co.yigil.auth.MemberOnly;
 import kr.co.yigil.auth.domain.Accessor;
+import kr.co.yigil.follow.dto.response.FollowerFindDto;
+import kr.co.yigil.follow.dto.response.FollowingFindDto;
 import kr.co.yigil.member.application.MemberService;
 import kr.co.yigil.member.dto.request.MemberUpdateRequest;
-import kr.co.yigil.member.dto.response.MemberCourseResponse;
 import kr.co.yigil.member.dto.response.MemberDeleteResponse;
-import kr.co.yigil.member.dto.response.MemberFollowerListResponse;
-import kr.co.yigil.member.dto.response.MemberFollowingListResponse;
 import kr.co.yigil.member.dto.response.MemberInfoResponse;
-import kr.co.yigil.member.dto.response.MemberSpotResponse;
 import kr.co.yigil.member.dto.response.MemberUpdateResponse;
+import kr.co.yigil.travel.dto.response.CourseFindDto;
+import kr.co.yigil.travel.dto.response.SpotFindDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,16 +43,53 @@ public class MemberController {
 
     @GetMapping("/api/v1/members/courses")
     @MemberOnly
-    public ResponseEntity<MemberCourseResponse> getMyCourseInfo(@Auth final Accessor accessor) {
-        final MemberCourseResponse response = memberService.getMemberCourseInfo(accessor.getMemberId());
+    public ResponseEntity<Slice<CourseFindDto>> getMyCourseInfo(
+        @Auth final Accessor accessor,
+        @PageableDefault(size = 5) Pageable pageable,
+        @RequestParam(name = "sortBy", defaultValue = "createdAt", required = false) String sortBy,
+        @RequestParam(name = "sortOrder", defaultValue = "desc", required = false) String sortOrder) {
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.fromString(sortOrder), sortBy));
+        final Slice<CourseFindDto> response = memberService.getMemberCourseInfo(accessor.getMemberId(), pageRequest);
         return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/api/v1/members/spots")
     @MemberOnly
-    public ResponseEntity<MemberSpotResponse> getMySpotInfo(@Auth final Accessor accessor) {
-        final MemberSpotResponse response = memberService.getMemberSpotInfo(accessor.getMemberId());
-        return ResponseEntity.ok().body(response);
+    public ResponseEntity<Slice<SpotFindDto>> getMySpotInfo(
+        @Auth final Accessor accessor,
+        @PageableDefault(size = 5) Pageable pageable,
+        @RequestParam(name = "sortBy", defaultValue = "createdAt", required = false) String sortBy,
+        @RequestParam(name = "sortOrder", defaultValue = "desc", required = false) String sortOrder
+        ) {
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.fromString(sortOrder), sortBy));
+        final Slice<SpotFindDto> spotListResponse = memberService.getMemberSpotInfo(accessor.getMemberId(), pageRequest);
+        return ResponseEntity.ok().body(spotListResponse);
+    }
+
+    @GetMapping("/api/v1/members/followers")
+    @MemberOnly
+    public ResponseEntity<Slice<FollowingFindDto>> getMyFollowerInfo(
+        @Auth final Accessor accessor,
+        @PageableDefault(size = 5) Pageable pageable,
+        @RequestParam(name = "sortBy", defaultValue = "createdAt", required = false) String sortBy,
+        @RequestParam(name = "sortOrder", defaultValue = "asc", required = false) String sortOrder
+    ){
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.fromString(sortOrder), sortBy));
+        final Slice<FollowingFindDto> follwerListResponse = memberService.getFollowingList(accessor.getMemberId(), pageRequest);
+        return ResponseEntity.ok().body(follwerListResponse);
+    }
+
+    @GetMapping("/api/v1/members/followings")
+    @MemberOnly
+    public ResponseEntity<Slice<FollowerFindDto>> getMyFollowingInfo(
+        @Auth final Accessor accessor,
+        @PageableDefault(size = 5) Pageable pageable,
+        @RequestParam(name = "sortBy", defaultValue = "createdAt", required = false) String sortBy,
+        @RequestParam(name = "sortOrder", defaultValue = "asc", required = false) String sortOrder
+    ){
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.fromString(sortOrder), sortBy));
+        final Slice<FollowerFindDto> follwingListResponse = memberService.getFollowerList(accessor.getMemberId(), pageRequest);
+        return ResponseEntity.ok().body(follwingListResponse);
     }
 
     @PostMapping("/api/v1/members")
@@ -73,14 +116,26 @@ public class MemberController {
     }
 
     @GetMapping("/api/v1/members/followers/{memberId}")
-    public ResponseEntity<MemberFollowerListResponse> getMemberFollowerList(@PathVariable("memberId") final Long memberId) {
-        MemberFollowerListResponse response = memberService.getFollowerList(memberId);
+    public ResponseEntity<Slice<FollowerFindDto>> getMemberFollowerList(
+        @PathVariable("memberId") final Long memberId,
+        @PageableDefault(size = 5) Pageable pageable,
+        @RequestParam(name = "sortBy", defaultValue = "createdAt", required = false) String sortBy,
+        @RequestParam(name = "sortOrder", defaultValue = "asc", required = false) String sortOrder
+        ) {
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.fromString(sortOrder), sortBy));
+        Slice<FollowerFindDto> response = memberService.getFollowerList(memberId, pageRequest);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/api/v1/members/followings/{memberId}")
-    public ResponseEntity<MemberFollowingListResponse> getMemberFollowingList(@PathVariable("memberId") final Long memberId) {
-        MemberFollowingListResponse response = memberService.getFollowingList(memberId);
+    public ResponseEntity<Slice<FollowingFindDto>> getMemberFollowingList(
+        @PathVariable("memberId") final Long memberId,
+        @PageableDefault(size = 5) Pageable pageable,
+        @RequestParam(name = "sortBy", defaultValue = "createdAt", required = false) String sortBy,
+        @RequestParam(name = "sortOrder", defaultValue = "asc", required = false) String sortOrder
+        ) {
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.fromString(sortOrder), sortBy));
+        Slice<FollowingFindDto> response = memberService.getFollowingList(memberId, pageRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/application/SpotService.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/application/SpotService.java
@@ -136,7 +136,7 @@ public class SpotService {
     }
 
     @NotNull
-    private SpotFindDto getSpotFindDto(Spot spot) {
+    public SpotFindDto getSpotFindDto(Spot spot) {
         return SpotFindDto.from(
             spot,
             favorRedisIntegrityService.ensureFavorCounts(spot).getFavorCount(),


### PR DESCRIPTION
## Motivation 🧐
#224 프론트에서 작업 중인 mypage와 백엔드와 연결이 필요해 Member 도메인의 수정이 필요함. 
<br>

## Key Changes 🔑
- 내 장소 조회를 slice 리스트로 보내도록 변경
- follow 목록 조회를 slice리스트로 보내도록 변경
- 위 변경사항을 위해 followerfinddto, followingfinddto 생성
- mypage에서 각각 course, spot, info, follower, following으로 api 호출 가능해짐
<br>

## To Reviewers 🙏
프론트와의 연결 확인해주시고 문제 있을 시 알려주시면 바로 수정하도록 하겠습니다!!