### PR TITLE
진행 표시줄 작성

### DIFF
--- a/frontend/src/app/_components/add/common/ProgressIndicator.tsx
+++ b/frontend/src/app/_components/add/common/ProgressIndicator.tsx
@@ -1,0 +1,21 @@
+import type { TStep } from './step/types';
+
+export default function ProgressIndicator({ step }: { step: TStep }) {
+  const { makingStep, inputStep } = step;
+
+  const label = makingStep.data.label;
+  const hideIndicator = label === '완료' || label.includes('확정');
+
+  const totalStepCount = inputStep.kind === 'from-new' ? 4 : 3;
+
+  return hideIndicator ? (
+    <></>
+  ) : (
+    <div
+      className="h-1 bg-black transition-all ease-in-out duration-300"
+      style={{
+        width: `${Math.floor((inputStep.data.value / totalStepCount) * 100)}%`,
+      }}
+    ></div>
+  );
+}

--- a/frontend/src/app/_components/add/common/step/constants.ts
+++ b/frontend/src/app/_components/add/common/step/constants.ts
@@ -6,7 +6,7 @@ export const COURSE_FROM_EXISTING_STEP_COUNT = 6;
 
 export const initialSpotStep: TStep = {
   makingStep: { kind: 'spot', data: { label: '장소 입력', value: 1 } },
-  inputStep: { kind: 'from-new', data: { label: '주소', value: 1 } },
+  inputStep: { kind: 'from-new', data: { label: '시작', value: 0 } },
 };
 
 export const initialCourseFromExistingStep: TStep = {
@@ -16,7 +16,7 @@ export const initialCourseFromExistingStep: TStep = {
   },
   inputStep: {
     kind: 'from-existing',
-    data: { label: '순서', value: 1 },
+    data: { label: '시작', value: 0 },
   },
 };
 
@@ -27,7 +27,7 @@ export const initialCourseFromNewStep: TStep = {
   },
   inputStep: {
     kind: 'from-new',
-    data: { label: '주소', value: 1 },
+    data: { label: '시작', value: 0 },
   },
 };
 

--- a/frontend/src/app/_components/add/common/step/index.ts
+++ b/frontend/src/app/_components/add/common/step/index.ts
@@ -46,7 +46,7 @@ export function makeInitialStep(
 function makeNextStep(step: TStep): TStep {
   const { makingStep, inputStep } = step;
 
-  if (makingStep.data.label === '정보 입력') {
+  if (makingStep.data.label === '장소 선택') {
     return {
       makingStep: nextMakingStep(makingStep, inputStep),
       inputStep: nextInputStep(makingStep, inputStep),
@@ -54,6 +54,20 @@ function makeNextStep(step: TStep): TStep {
   }
 
   if (makingStep.data.label === '순서 결정') {
+    return {
+      makingStep: nextMakingStep(makingStep, inputStep),
+      inputStep: nextInputStep(makingStep, inputStep),
+    };
+  }
+
+  if (makingStep.data.label === '장소 입력') {
+    return {
+      makingStep: nextMakingStep(makingStep, inputStep),
+      inputStep: nextInputStep(makingStep, inputStep),
+    };
+  }
+
+  if (makingStep.data.label === '정보 입력') {
     return {
       makingStep: nextMakingStep(makingStep, inputStep),
       inputStep: nextInputStep(makingStep, inputStep),
@@ -70,6 +84,13 @@ function makePreviousStep(step: TStep): TStep {
   const { makingStep, inputStep } = step;
 
   if (makingStep.data.label === '정보 입력') {
+    return {
+      makingStep: previousMakingStep(makingStep, inputStep),
+      inputStep: previousInputStep(makingStep, inputStep),
+    };
+  }
+
+  if (makingStep.data.label === '순서 결정') {
     return {
       makingStep: previousMakingStep(makingStep, inputStep),
       inputStep: previousInputStep(makingStep, inputStep),
@@ -148,6 +169,9 @@ function nextInputStep(
 
   switch (kind) {
     case 'from-new': {
+      if (data.label === '시작') {
+        return { kind, data: { label: '주소', value: 1 } };
+      }
       if (data.label === '주소') {
         return { kind, data: { label: '사진', value: 2 } };
       }
@@ -160,12 +184,14 @@ function nextInputStep(
       return { kind, data };
     }
     case 'from-existing': {
-      if (data.label === '순서') {
-        if (step.data.label === '순서 결정') {
-          return { kind, data: { label: '별점', value: 2 } };
+      if (data.label === '시작') {
+        if (step.data.label === '장소 선택') {
+          return { kind, data: { label: '순서', value: 1 } };
         }
-
         return { kind, data };
+      }
+      if (data.label === '순서') {
+        return { kind, data: { label: '별점', value: 2 } };
       }
       if (data.label === '별점') {
         return { kind, data: { label: '리뷰', value: 3 } };
@@ -249,6 +275,9 @@ function previousInputStep(
       if (data.label === '사진') {
         return { kind, data: { label: '주소', value: 1 } };
       }
+      if (data.label === '주소') {
+        return { kind, data: { label: '시작', value: 0 } };
+      }
       return { kind, data };
     }
     case 'from-existing': {
@@ -257,6 +286,9 @@ function previousInputStep(
       }
       if (data.label === '별점') {
         return { kind, data: { label: '순서', value: 1 } };
+      }
+      if (data.label === '순서') {
+        return { kind, data: { label: '시작', value: 0 } };
       }
       return { kind, data };
     }

--- a/frontend/src/app/_components/add/common/step/types/dataInput.ts
+++ b/frontend/src/app/_components/add/common/step/types/dataInput.ts
@@ -1,10 +1,12 @@
 type TDataFromNewStep =
+  | { label: '시작'; value: 0 }
   | { label: '주소'; value: 1 }
   | { label: '사진'; value: 2 }
   | { label: '별점'; value: 3 }
   | { label: '리뷰'; value: 4 };
 
 type TDataFromExistingStep =
+  | { label: '시작'; value: 0 }
   | { label: '순서'; value: 1 }
   | { label: '별점'; value: 2 }
   | { label: '리뷰'; value: 3 };


### PR DESCRIPTION
## Motivation 🧐
#218 에 의거하여, 진행 표시줄을 작성했습니다.

## Key Changes 🔑
- prop으로 전달받은 현재 단계에 알맞게 진행 표시줄을 그리도록 구현했습니다.
- 자연스러운 애니메이션을 위해 `TDataInputStep`에 명시적인 '시작' 단계를 추가했습니다.
- '시작' 단계가 추가되었으므로, 상태 전이 코드를 작성했습니다.
- '완료' 단계, '~ 확정' 단계에서는 표시줄이 그려지지 않게 했습니다.

## To Reviewers 🙏
