### PR TITLE
장소 추가 플로우 코드 수정

### DIFF
--- a/frontend/src/app/_components/add/AddSpot.tsx
+++ b/frontend/src/app/_components/add/AddSpot.tsx
@@ -52,6 +52,9 @@ export default function AddSpot() {
   const stepLabel = makingSpotStep.data.label;
   const inputLabel = dataFromNewStep.data.label;
 
+  /**
+   * @todo 장소 검색 server action 추가
+   */
   async function search(keyword: string) {
     if (keyword === '') {
       setSearchResults([]);

--- a/frontend/src/app/_components/add/AddSpot.tsx
+++ b/frontend/src/app/_components/add/AddSpot.tsx
@@ -10,24 +10,13 @@ import {
   initialAddSpotState,
 } from './spot/SpotContext';
 
-import type { DataInput, Making } from './common/step/types';
+import * as Common from './common';
 
 import SearchBox from '../search';
-import SpotCheck from './common/SpotCheck';
-import InfoTitle from './common/InfoTitle';
-import AddPlaceInfo from './common/AddPlaceInto';
-import { ImageHandler } from '../images';
-import PostRating from './common/PostRating';
-import PostReview from './common/PostReview';
-import AddSpotMap from './common/AddSpotMap';
+import ImageHandler from '../images';
 import MapComponent from '../naver-map/MapComponent';
-import AddConfirmContent from './common/AddConfirmContent';
 
-/** 배포용 추가 */
-const url =
-  process.env.NODE_ENV !== 'production'
-    ? 'http://localhost:3000/endpoints/api/search'
-    : 'https://yigil.co.kr/endpoints/api/search';
+import type { DataInput, Making } from './common/step/types';
 
 export default function AddSpot() {
   const [step, dispatchStep] = useReducer(
@@ -61,6 +50,11 @@ export default function AddSpot() {
       return;
     }
 
+    const url =
+      process.env.NODE_ENV !== 'production'
+        ? 'http://localhost:3000/endpoints/api/search'
+        : 'https://yigil.co.kr/endpoints/api/search';
+
     const res = await fetch(url, {
       method: 'POST',
       body: JSON.stringify({ keyword }),
@@ -79,6 +73,14 @@ export default function AddSpot() {
     setSearchResults(results);
   }
 
+  // 검색을 통해 선택한 장소
+  // Drilling이 심하게 일어나는 것같기도?
+  const [currentFoundPlace, setCurrentFoundPlace] = useState<{
+    name: string;
+    roadAddress: string;
+    coords: { lat: number; lng: number };
+  }>();
+
   return (
     <section className="flex flex-col grow">
       <AddSpotContext.Provider value={addSpotState}>
@@ -92,16 +94,16 @@ export default function AddSpot() {
         {stepLabel === '장소 입력' && (
           <section className=" flex flex-col justify-between grow">
             <SearchBox
-              dispatchSpot={dispatchSpot}
-              dispatchStep={dispatchStep}
               searchResults={searchResults}
               search={search}
+              setCurrentFoundPlace={setCurrentFoundPlace}
             />
             <hr className="my-2 pb-1 align-bottom" />
             <MapComponent width="100%" height="100%">
-              <AddSpotMap
-                title={addSpotState.name}
-                coords={addSpotState.coords}
+              <Common.AddSpotMap
+                place={currentFoundPlace}
+                dispatchStep={dispatchStep}
+                dispatchSpot={dispatchSpot}
               />
             </MapComponent>
           </section>
@@ -111,13 +113,16 @@ export default function AddSpot() {
             {inputLabel === '시작' && <></>}
             {inputLabel === '주소' && (
               <>
-                <InfoTitle label={inputLabel} additionalLabel="를 확인하세요" />
-                <AddPlaceInfo />
+                <Common.InfoTitle
+                  label={inputLabel}
+                  additionalLabel="를 확인하세요"
+                />
+                <Common.AddPlaceInfo />
               </>
             )}
             {inputLabel === '사진' && (
               <>
-                <InfoTitle
+                <Common.InfoTitle
                   label={inputLabel}
                   additionalLabel="을 업로드하세요"
                 />
@@ -126,20 +131,26 @@ export default function AddSpot() {
             )}
             {inputLabel === '별점' && (
               <>
-                <InfoTitle label={inputLabel} additionalLabel="을 매기세요" />
-                <PostRating dispatch={dispatchSpot} />
+                <Common.InfoTitle
+                  label={inputLabel}
+                  additionalLabel="을 매기세요"
+                />
+                <Common.PostRating dispatch={dispatchSpot} />
               </>
             )}
             {inputLabel === '리뷰' && (
               <>
-                <InfoTitle label={inputLabel} additionalLabel="를 남기세요" />
-                <PostReview dispatch={dispatchSpot} />
+                <Common.InfoTitle
+                  label={inputLabel}
+                  additionalLabel="를 남기세요"
+                />
+                <Common.PostReview dispatch={dispatchSpot} />
               </>
             )}
           </>
         )}
-        {stepLabel === '장소 확정' && <SpotCheck />}
-        {stepLabel === '완료' && <AddConfirmContent />}
+        {stepLabel === '장소 확정' && <Common.SpotCheck />}
+        {stepLabel === '완료' && <Common.AddConfirmContent />}
       </AddSpotContext.Provider>
     </section>
   );

--- a/frontend/src/app/_components/add/common/AddPlaceInto.tsx
+++ b/frontend/src/app/_components/add/common/AddPlaceInto.tsx
@@ -2,9 +2,6 @@
 
 import { useContext } from 'react';
 import { AddSpotContext } from '../spot/SpotContext';
-import { httpRequest } from '../../api/httpRequest';
-
-// 이름과 주소를 입력으로 하여 static map 저장 여부를 반환하는 API가 필요함
 
 // 외부 placeholder 이미지 사용중, no-img-element 린트 에러 발생
 // 차후 next/image 사용하게 변경 예정

--- a/frontend/src/app/_components/add/common/AddSpotMap.tsx
+++ b/frontend/src/app/_components/add/common/AddSpotMap.tsx
@@ -1,25 +1,33 @@
 'use client';
-import React, { useRef } from 'react';
+import React, { Dispatch, useRef } from 'react';
 import { Listener, NaverMap, Overlay, useNavermaps } from 'react-naver-maps';
 
+import type { TAddSpotAction } from '../spot/SpotContext';
+
 export default function AddSpotMap({
-  coords,
-  title,
-}: // next 함수
-{
-  coords: { lat: number; lng: number };
-  title: string;
+  place,
+  dispatchStep,
+  dispatchSpot,
+}: {
+  place?: {
+    name: string;
+    roadAddress: string;
+    coords: { lat: number; lng: number };
+  };
+  dispatchStep: Dispatch<{ type: 'next' } | { type: 'previous' }>;
+  dispatchSpot: Dispatch<TAddSpotAction>;
 }) {
   const navermaps = useNavermaps();
   const info = useRef<any>(null);
 
-  if (!info.current) {
+  // 이렇게 해도 장소 선택이 바뀔 때마다 마커가 갱신되나요?
+  if (!info.current && place) {
     info.current = new navermaps.Marker({
-      position: coords,
+      position: place.coords,
       icon: {
         content: `<div style=" border: 1px #60a5fa solid; border-radius: 5px; background-color: #fff;">
         <div style="display: flex; padding: 8px 10px">
-        <div style="padding:0px 8px 0px 0px; color:#374151; font-size: 18px; font-weight: 600; text-align: center;">${title}</div>
+        <div style="padding:0px 8px 0px 0px; color:#374151; font-size: 18px; font-weight: 600; text-align: center;">${place.name}</div>
         <div style="display:flex; justify-content: center; align-items: center;">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <rect width="24" height="24" rx="12" fill="#60A5FA"/>
@@ -36,14 +44,37 @@ export default function AddSpotMap({
   }
   const infoWindow = info.current;
 
+  /**
+   * @todo static map url 얻어오는 server action 추가
+   * 1. 백엔드 서버에 있는지 질의
+   * 2. 없으면 네이버에 질의
+   * 3. 얻어온 URL을 dispatchSpot에 제공
+   */
+  function handleClick(place: {
+    name: string;
+    roadAddress: string;
+    coords: { lat: number; lng: number };
+  }) {
+    const { name, roadAddress, coords } = place;
+
+    // Server Action 위치
+
+    dispatchSpot({ type: 'SET_NAME', payload: name });
+    dispatchSpot({ type: 'SET_ADDRESS', payload: roadAddress });
+    dispatchSpot({ type: 'SET_COORDS', payload: coords });
+    dispatchStep({ type: 'next' });
+  }
+
   return (
     <NaverMap
       defaultCenter={new naver.maps.LatLng(37.5452605, 127.0526252)}
       zoom={15}
     >
-      <Overlay element={infoWindow}>
-        <Listener type="click" listener={() => window.alert('clicked')} />
-      </Overlay>
+      {place && (
+        <Overlay element={infoWindow}>
+          <Listener type="click" listener={() => handleClick(place)} />
+        </Overlay>
+      )}
     </NaverMap>
   );
 }

--- a/frontend/src/app/_components/add/common/AddSpotMap.tsx
+++ b/frontend/src/app/_components/add/common/AddSpotMap.tsx
@@ -1,6 +1,13 @@
 'use client';
-import React, { Dispatch, useRef } from 'react';
-import { Listener, NaverMap, Overlay, useNavermaps } from 'react-naver-maps';
+import React, { Dispatch, useEffect, useRef, useState } from 'react';
+import {
+  Listener,
+  Marker,
+  NaverMap,
+  Overlay,
+  useNavermaps,
+} from 'react-naver-maps';
+import { plusMarker } from '../../naver-map/plusMarker';
 
 import type { TAddSpotAction } from '../spot/SpotContext';
 
@@ -18,31 +25,65 @@ export default function AddSpotMap({
   dispatchSpot: Dispatch<TAddSpotAction>;
 }) {
   const navermaps = useNavermaps();
-  const info = useRef<any>(null);
+  const markerRef = useRef<naver.maps.Marker | null>(null);
+  const mapRef = useRef<naver.maps.Map>(null);
+  const [center, setCenter] = useState<{ lat: number; lng: number }>({
+    lat: 37.5135869,
+    lng: 127.0621708,
+  });
 
-  // 이렇게 해도 장소 선택이 바뀔 때마다 마커가 갱신되나요?
-  if (!info.current && place) {
-    info.current = new navermaps.Marker({
-      position: place.coords,
-      icon: {
-        content: `<div style=" border: 1px #60a5fa solid; border-radius: 5px; background-color: #fff;">
-        <div style="display: flex; padding: 8px 10px">
-        <div style="padding:0px 8px 0px 0px; color:#374151; font-size: 18px; font-weight: 600; text-align: center;">${place.name}</div>
-        <div style="display:flex; justify-content: center; align-items: center;">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect width="24" height="24" rx="12" fill="#60A5FA"/>
-        <path d="M12 6.16663V17.8333" stroke="white" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M6.16797 12H17.8346" stroke="white" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        </div>
-        </div>
-        <div style="position:absolute; bottom:-5px; left:50px; width: 12px; height:12px;background-color:#fff; border-bottom: 1px #60a5fa solid; border-right:1px #60a5fa solid; transform: rotate(45deg);"></div>
-        </div>`,
-        anchor: new navermaps.Point(50, 50),
-      },
+  function onSuccessGeolocation(position: {
+    coords: { latitude: number; longitude: number };
+  }) {
+    if (!mapRef.current) return;
+
+    const location = new navermaps.LatLng(
+      position.coords.latitude,
+      position.coords.longitude,
+    );
+    mapRef.current.setCenter(location);
+    mapRef.current.setZoom(15);
+
+    setCenter({
+      lat: position.coords.latitude,
+      lng: position.coords.longitude,
     });
   }
-  const infoWindow = info.current;
+
+  function onErrorGeolocation() {
+    if (!mapRef.current) return;
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        onSuccessGeolocation,
+        onErrorGeolocation,
+      );
+    } else {
+      setCenter({ lat: 37.5452605, lng: 127.0526252 });
+    }
+  }
+
+  useEffect(() => {
+    if (!mapRef.current) {
+      return;
+    }
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        onSuccessGeolocation,
+        onErrorGeolocation,
+      );
+    } else {
+      setCenter({ lat: 37.5452605, lng: 127.0526252 });
+    }
+  }, [mapRef]);
+
+  useEffect(() => {
+    if (mapRef.current && place) {
+      const coord = { ...place.coords };
+      mapRef.current.panTo(coord);
+    }
+  }, []);
 
   /**
    * @todo static map url 얻어오는 server action 추가
@@ -55,8 +96,7 @@ export default function AddSpotMap({
     roadAddress: string;
     coords: { lat: number; lng: number };
   }) {
-    const { name, roadAddress, coords } = place;
-
+    const { name: title, roadAddress, coords } = place;
     // Server Action 위치
 
     dispatchSpot({ type: 'SET_NAME', payload: name });
@@ -67,13 +107,22 @@ export default function AddSpotMap({
 
   return (
     <NaverMap
-      defaultCenter={new naver.maps.LatLng(37.5452605, 127.0526252)}
+      center={
+        place
+          ? new naver.maps.LatLng({ ...place?.coords })
+          : new naver.maps.LatLng({ ...center })
+      }
       zoom={15}
+      ref={mapRef}
     >
       {place && (
-        <Overlay element={infoWindow}>
-          <Listener type="click" listener={() => handleClick(place)} />
-        </Overlay>
+        <Marker
+          ref={markerRef}
+          title={place.name}
+          position={place.coords}
+          icon={plusMarker(place)}
+          onClick={() => console.log('clicked')}
+        ></Marker>
       )}
     </NaverMap>
   );

--- a/frontend/src/app/_components/add/common/AddSpotMap.tsx
+++ b/frontend/src/app/_components/add/common/AddSpotMap.tsx
@@ -96,7 +96,7 @@ export default function AddSpotMap({
     roadAddress: string;
     coords: { lat: number; lng: number };
   }) {
-    const { name: title, roadAddress, coords } = place;
+    const { name, roadAddress, coords } = place;
     // Server Action 위치
 
     dispatchSpot({ type: 'SET_NAME', payload: name });
@@ -121,7 +121,7 @@ export default function AddSpotMap({
           title={place.name}
           position={place.coords}
           icon={plusMarker(place)}
-          onClick={() => console.log('clicked')}
+          onClick={() => handleClick(place)}
         ></Marker>
       )}
     </NaverMap>

--- a/frontend/src/app/_components/add/common/PostRating.tsx
+++ b/frontend/src/app/_components/add/common/PostRating.tsx
@@ -1,12 +1,14 @@
 'use client';
-import { EventFor } from '@/types/type';
-import React, { useContext, useState } from 'react';
+
+import { useContext, useState } from 'react';
+import { AddSpotContext } from '../spot/SpotContext';
+
 import StarIcon from '/public/icons/star.svg';
 
 import type { Dispatch } from 'react';
-import { AddSpotContext, type TAddSpotAction } from '../spot/SpotContext';
+import type { EventFor } from '@/types/type';
+import type { TAddSpotAction } from '../spot/SpotContext';
 
-/** setRating 함수를 props로 받아야 함 */
 export default function PostRating({
   dispatch,
 }: {

--- a/frontend/src/app/_components/add/common/PostReview.tsx
+++ b/frontend/src/app/_components/add/common/PostReview.tsx
@@ -1,7 +1,13 @@
 'use client';
-import { EventFor } from '@/types/type';
-import React, { Dispatch, SetStateAction, useContext, useState } from 'react';
-import { AddSpotContext, TAddSpotAction } from '../spot/SpotContext';
+
+import { useContext } from 'react';
+
+import { AddSpotContext } from '../spot/SpotContext';
+
+import type { Dispatch } from 'react';
+import type { EventFor } from '@/types/type';
+
+import type { TAddSpotAction } from '../spot/SpotContext';
 
 interface TPostReviewProps {
   viewTitle?: boolean;

--- a/frontend/src/app/_components/add/common/index.ts
+++ b/frontend/src/app/_components/add/common/index.ts
@@ -1,0 +1,17 @@
+import SpotCheck from './SpotCheck';
+import InfoTitle from './InfoTitle';
+import AddPlaceInfo from './AddPlaceInto';
+import PostRating from './PostRating';
+import PostReview from './PostReview';
+import AddSpotMap from './AddSpotMap';
+import AddConfirmContent from './AddConfirmContent';
+
+export {
+  SpotCheck,
+  InfoTitle,
+  AddPlaceInfo,
+  PostRating,
+  PostReview,
+  AddSpotMap,
+  AddConfirmContent,
+};

--- a/frontend/src/app/_components/add/common/step/StepNavigation.tsx
+++ b/frontend/src/app/_components/add/common/step/StepNavigation.tsx
@@ -1,4 +1,6 @@
 import { useContext, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
 import { AddSpotContext } from '../../spot/SpotContext';
 
 import XMarkIcon from '/public/icons/x-mark.svg';
@@ -37,6 +39,8 @@ export default function StepNavigation({
   next: () => void;
   previous: () => void;
 }) {
+  const { back } = useRouter();
+
   const [isOpen, setIsOpen] = useState(false);
 
   const { makingStep } = currentStep;
@@ -78,7 +82,7 @@ export default function StepNavigation({
   return (
     <nav className="mx-2 py-4 flex justify-between items-center relative">
       {value === 1 ? (
-        <button className="w-12 p-2">
+        <button className="w-12 p-2" onClick={() => back()}>
           <XMarkIcon className="w-6 h-6 stroke-gray-500" />
         </button>
       ) : (

--- a/frontend/src/app/_components/add/common/step/StepNavigation.tsx
+++ b/frontend/src/app/_components/add/common/step/StepNavigation.tsx
@@ -82,7 +82,7 @@ export default function StepNavigation({
   return (
     <nav className="mx-2 py-4 flex justify-between items-center relative">
       {value === 1 ? (
-        <button className="w-12 p-2" onClick={() => back()}>
+        <button className="w-12 p-2" onClick={back}>
           <XMarkIcon className="w-6 h-6 stroke-gray-500" />
         </button>
       ) : (
@@ -108,7 +108,7 @@ export default function StepNavigation({
           )}
         </button>
       ) : (
-        <button className="w-12 p-2 text-gray-500" onClick={() => next()}>
+        <button className="w-12 p-2 text-gray-500" onClick={next}>
           다음
         </button>
       )}

--- a/frontend/src/app/_components/add/common/step/StepNavigation.tsx
+++ b/frontend/src/app/_components/add/common/step/StepNavigation.tsx
@@ -23,12 +23,6 @@ function dataUrlToBlob(dataURI: string) {
   return new Blob([ab], { type: mimeString });
 }
 
-/** 배포용 추가 */
-const url =
-  process.env.NODE_ENV !== 'production'
-    ? 'http://localhost:3000/endpoints/api/spot'
-    : 'https://yigil.co.kr/endpoints/api/spot';
-
 /**
  * `next` - 상위 컴포넌트에서 `dispatch({ type: 'next' })`를 감싼 이벤트 핸들러
  *
@@ -59,22 +53,18 @@ export default function StepNavigation({
     setIsOpen(false);
   }
 
+  /**
+   * @todo dataUrlToBlob를 이용해 Image를 File로 변환하여 전달
+   * @todo Spot 추가하는 server action 필요
+   */
   function handleConfirm() {
     console.log(state);
     console.log('Confirm!');
-    /**경택 추가 */
-    addSpot();
+
+    // server action 위치
+
     setIsOpen(false);
     next();
-  }
-
-  /** 경택 추가:spot 추가하는 함수 */
-  async function addSpot() {
-    const res = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(state),
-    });
-    console.log(res);
   }
 
   if (label === '완료') {

--- a/frontend/src/app/_components/images/ImageHandler.tsx
+++ b/frontend/src/app/_components/images/ImageHandler.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
 import ImageInput from './ImageInput';
 import ImagesContainer from './ImagesContainer';
+import { AddSpotContext } from '../add/spot/SpotContext';
 
-import type { Dispatch, SetStateAction } from 'react';
-import { AddSpotContext, TAddSpotAction } from '../add/spot/SpotContext';
+import type { Dispatch } from 'react';
+
+import type { TAddSpotAction } from '../add/spot/SpotContext';
 
 export interface TImageData {
   filename: string;

--- a/frontend/src/app/_components/images/ImagesContainer.tsx
+++ b/frontend/src/app/_components/images/ImagesContainer.tsx
@@ -19,6 +19,7 @@ import {
 
 import ImageItem from './ImageItem';
 import SortableItem from './SortableItem';
+import { AddSpotContext } from '../add/spot/SpotContext';
 
 import type { Dispatch } from 'react';
 import type {
@@ -26,8 +27,9 @@ import type {
   DragStartEvent,
   UniqueIdentifier,
 } from '@dnd-kit/core';
+
 import type { TImageData } from './ImageHandler';
-import { AddSpotContext, type TAddSpotAction } from '../add/spot/SpotContext';
+import type { TAddSpotAction } from '../add/spot/SpotContext';
 
 export default function ImagesContainer({
   dispatch,

--- a/frontend/src/app/_components/images/SortableItem.tsx
+++ b/frontend/src/app/_components/images/SortableItem.tsx
@@ -2,6 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
 import ImageItem from './ImageItem';
+
 import type { TImageData } from './ImageHandler';
 
 export default function SortableItem({

--- a/frontend/src/app/_components/images/index.ts
+++ b/frontend/src/app/_components/images/index.ts
@@ -1,3 +1,3 @@
 import ImageHandler from './ImageHandler';
 
-export { ImageHandler };
+export default ImageHandler;

--- a/frontend/src/app/_components/naver-map/plusMarker.ts
+++ b/frontend/src/app/_components/naver-map/plusMarker.ts
@@ -1,0 +1,18 @@
+export const plusMarker = (place: { name: string }) => {
+  return {
+    content: `<div style=" border: 1px #60a5fa solid; border-radius: 5px; background-color: #fff; word-break:keep-all;">
+  <div style="display: flex; padding: 8px 10px">
+  <div style="padding:0px 8px 0px 0px; color:#374151; font-size: 18px; font-weight: 600; text-align: center;">${place.name}</div>
+  <div style="display:flex; justify-content: center; align-items: center;">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="24" rx="12" fill="#60A5FA"/>
+  <path d="M12 6.16663V17.8333" stroke="white" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.16797 12H17.8346" stroke="white" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+  </div>
+  </div>
+  <div style="position:absolute; bottom:-5px; left:50px; width: 12px; height:12px;background-color:#fff; border-bottom: 1px #60a5fa solid; border-right:1px #60a5fa solid; transform: rotate(45deg);"></div>
+  </div>`,
+    anchor: new naver.maps.Point(50, 50),
+  };
+};

--- a/frontend/src/app/_components/search/SearchBox.tsx
+++ b/frontend/src/app/_components/search/SearchBox.tsx
@@ -6,8 +6,7 @@ import SearchBar from './SearchBar';
 import SearchHistory from './SearchHistory';
 import SearchResult from './SearchResult';
 
-import type { Dispatch } from 'react';
-import type { TAddSpotAction } from '../add/spot/SpotContext';
+import type { Dispatch, SetStateAction } from 'react';
 
 const SEARCH_HISTORY_KEY = 'search-history';
 
@@ -21,17 +20,25 @@ function parseSearchHistory(historyStr: string | null) {
 
 export default function SearchBox({
   showHistory,
-  dispatchSpot,
-  dispatchStep,
   searchResults,
   search,
+  setCurrentFoundPlace,
 }: {
   showHistory?: boolean;
-  dispatchSpot: Dispatch<TAddSpotAction>;
-  dispatchStep: Dispatch<{ type: 'next' } | { type: 'previous' }>;
   searchResults: { name: string; roadAddress: string }[];
   search: (keyword: string) => Promise<void>;
+  setCurrentFoundPlace: Dispatch<
+    SetStateAction<
+      | {
+          name: string;
+          roadAddress: string;
+          coords: { lat: number; lng: number };
+        }
+      | undefined
+    >
+  >;
 }) {
+  const [showResult, setShowResult] = useState(false);
   const [searchHistory, setSearchHistory] = useState<string[]>(() => {
     if (typeof window !== 'undefined') {
       return parseSearchHistory(localStorage.getItem(SEARCH_HISTORY_KEY));
@@ -61,6 +68,14 @@ export default function SearchBox({
     }
   }
 
+  function openResults() {
+    setShowResult(true);
+  }
+
+  function closeResults() {
+    setShowResult(false);
+  }
+
   const searchHistoryProps = {
     deleteHistory,
     deleteHistoryAll,
@@ -70,14 +85,20 @@ export default function SearchBox({
   // 검색어 자동완성 기능 구현될 시 conditional rendering
   return (
     <section className="flex flex-col">
-      <SearchBar search={search} addHistory={addHistory} cancellable />
+      <SearchBar
+        search={search}
+        addHistory={addHistory}
+        openResults={openResults}
+        closeResults={closeResults}
+        cancellable
+      />
       <div className="grow" aria-label="Result/History container">
         {showHistory && <SearchHistory {...searchHistoryProps} />}
-        {searchResults.length !== 0 && (
+        {showResult && (
           <SearchResult
-            dispatchSpot={dispatchSpot}
-            dispatchStep={dispatchStep}
             searchResults={searchResults}
+            closeResults={closeResults}
+            setCurrentFoundPlace={setCurrentFoundPlace}
           />
         )}
       </div>

--- a/frontend/src/app/_components/search/SearchBox.tsx
+++ b/frontend/src/app/_components/search/SearchBox.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Dispatch, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import SearchBar from './SearchBar';
 import SearchHistory from './SearchHistory';
-
-import type { TAddSpotAction } from '../add/spot/SpotContext';
 import SearchResult from './SearchResult';
+
+import type { Dispatch } from 'react';
+import type { TAddSpotAction } from '../add/spot/SpotContext';
 
 const SEARCH_HISTORY_KEY = 'search-history';
 

--- a/frontend/src/app/_components/search/SearchResult.tsx
+++ b/frontend/src/app/_components/search/SearchResult.tsx
@@ -1,33 +1,34 @@
-import { Dispatch } from 'react';
-import { TAddSpotAction } from '../add/spot/SpotContext';
-import { httpRequest } from '../api/httpRequest';
 import SearchIcon from '/public/icons/search.svg';
 
-/** 배포용 추가 */
-const coordsUrl =
-  process.env.NODE_ENV !== 'production'
-    ? 'http://localhost:3000/endpoints/api/coords'
-    : 'https://yigil.co.kr/endpoints/api/coords';
-
-const placeIdUrl =
-  process.env.NODE_ENV !== 'production'
-    ? 'http://localhost:3000/endpoints/api/placeId'
-    : 'https://yigil.co.kr/endpoints/api/placeId';
+import type { Dispatch, SetStateAction } from 'react';
 
 export default function SearchResult({
-  dispatchSpot,
-  dispatchStep,
   searchResults,
+  closeResults,
+  setCurrentFoundPlace,
 }: {
-  dispatchSpot: Dispatch<TAddSpotAction>;
-  dispatchStep: Dispatch<{ type: 'next' } | { type: 'previous' }>;
   searchResults: { name: string; roadAddress: string }[];
+  closeResults: () => void;
+  setCurrentFoundPlace: Dispatch<
+    SetStateAction<
+      | {
+          name: string;
+          roadAddress: string;
+          coords: { lat: number; lng: number };
+        }
+      | undefined
+    >
+  >;
 }) {
   /**
    * @todo 좌표 얻어오는 server action 추가
-   * @todo static map url 얻어오는 server action 추가
    */
   async function handleClick(name: string, roadAddress: string) {
+    const coordsUrl =
+      process.env.NODE_ENV !== 'production'
+        ? 'http://localhost:3000/endpoints/api/coords'
+        : 'https://yigil.co.kr/endpoints/api/coords';
+
     const res = await fetch(coordsUrl, {
       method: 'POST',
       body: JSON.stringify({ address: roadAddress }),
@@ -35,29 +36,9 @@ export default function SearchResult({
 
     const coords = (await res.json()) as { lat: number; lng: number };
 
-    const mapUrl = await httpRequest('places/static-image')(
-      `?name=${name}&address=${roadAddress}`,
-    )()()();
+    setCurrentFoundPlace({ name, roadAddress, coords });
 
-    const naverMapUrl = await fetch(placeIdUrl, {
-      method: 'POST',
-      body: JSON.stringify({ coords }),
-    });
-    console.log(naverMapUrl);
-
-    const mapUrlFromBackend = mapUrl?.code ? mapUrl.map_static_image_url : '';
-
-    const mapUrlFromNaver = '';
-
-    dispatchSpot({ type: 'SET_NAME', payload: name });
-    dispatchSpot({ type: 'SET_ADDRESS', payload: roadAddress });
-    dispatchSpot({ type: 'SET_COORDS', payload: coords });
-
-    if (mapUrlFromBackend) {
-      dispatchSpot({ type: 'SET_SPOT_MAP_URL', payload: mapUrl });
-    }
-
-    dispatchStep({ type: 'next' });
+    closeResults();
   }
 
   return (

--- a/frontend/src/app/_components/search/SearchResult.tsx
+++ b/frontend/src/app/_components/search/SearchResult.tsx
@@ -23,6 +23,10 @@ export default function SearchResult({
   dispatchStep: Dispatch<{ type: 'next' } | { type: 'previous' }>;
   searchResults: { name: string; roadAddress: string }[];
 }) {
+  /**
+   * @todo 좌표 얻어오는 server action 추가
+   * @todo static map url 얻어오는 server action 추가
+   */
   async function handleClick(name: string, roadAddress: string) {
     const res = await fetch(coordsUrl, {
       method: 'POST',


### PR DESCRIPTION
## Motivation 🧐
중간 배포를 위해 임시로 작업된 코드를 정리합니다.

## Key Changes 🔑
- 여러 import 구문을 정리했습니다.
- Server Action 도입에 따라 달라져야 하는 부분에 JSDoc `@todo` 주석을 추가했습니다.
- 검색어 선택 시 마커를 찍도록 동작을 변경했습니다.
- 마커 선택 시 장소를 선택하도록 구현했습니다.
- 추가 플로우 첫 화면의 X 버튼을 누르면 이전 화면으로 돌아가도록 구현했습니다.
- 배포를 위해 추가된 프로덕션용 URL 선언을 제거하거나, 이후 Server Action 도입 후 `fetch` call과 함께 제거하기 쉽도록 위치를 옮겼습니다.

## To Reviewers 🙏
1. Map에 찍히는 마커는 검색 결과에서 새로운 결과를 선택할 때마다 바뀌어야 하는데, 잠깐 작동시켜보니 바뀌지 않는 문제가 있었습니다. 제 환경에서만 그런지 모르겠네요.
2. 마커 생성에 넘겨줄 장소 정보를 어떻게 관리해야할지 고민해봐야 합니다. 지금은 `AddSpot`, 즉 최상단 컴포넌트에서 props로 넘겨주고 있는데, drilling이 좀 심하게 일어나고 있는 것 같기도 해서 Context로 빼야하나 봐야할 거 같아요.