### PR TITLE
FAB 및 PopOver 수정

### DIFF
--- a/frontend/src/app/(with-header)/(home)/page.tsx
+++ b/frontend/src/app/(with-header)/(home)/page.tsx
@@ -3,6 +3,16 @@ import { PlaceList } from '@/app/_components/place';
 import { placeData } from '@/app/_components/place/constants';
 import { homePopOverData } from '@/app/_components/ui/popover/constants';
 
+import PlusIcon from '@/../public/icons/plus.svg';
+
+function OpenedFABIcon() {
+  return <PlusIcon className="rotate-45 duration-200 z-30" />;
+}
+
+function ClosedFABIcon() {
+  return <PlusIcon className="rotate-0 duration-200" />;
+}
+
 export default async function HomePage() {
   return (
     <main className="max-w-full flex flex-col gap-4 relative">
@@ -11,6 +21,8 @@ export default async function HomePage() {
       <FloatingActionButton
         popOverData={homePopOverData}
         backdropStyle="bg-black bg-opacity-10"
+        openedIcon={<OpenedFABIcon />}
+        closedIcon={<ClosedFABIcon />}
       />
     </main>
   );

--- a/frontend/src/app/_components/FloatingActionButton.tsx
+++ b/frontend/src/app/_components/FloatingActionButton.tsx
@@ -1,17 +1,23 @@
 'use client';
-import PlusIcon from '@/../public/icons/plus.svg';
+
 import { useState } from 'react';
 import PopOver from './ui/popover/PopOver';
-import { TPopOverData } from './ui/popover/types';
+
+import type { ReactElement } from 'react';
+import type { TPopOverData } from './ui/popover/types';
 
 interface TFloatingActionButton {
   popOverData: TPopOverData[];
   backdropStyle?: string;
+  openedIcon: ReactElement;
+  closedIcon: ReactElement;
 }
 
 export default function FloatingActionButton({
   popOverData,
   backdropStyle,
+  openedIcon,
+  closedIcon,
 }: TFloatingActionButton) {
   const [isModalOpened, setIsModalOpened] = useState(false);
 
@@ -27,13 +33,7 @@ export default function FloatingActionButton({
         }`}
         onClick={() => setIsModalOpened(!isModalOpened)}
       >
-        <PlusIcon
-          className={`${
-            isModalOpened
-              ? 'rotate-45 duration-200 z-30'
-              : 'rotate-0 duration-200'
-          } `}
-        />
+        {isModalOpened ? openedIcon : closedIcon}
         {isModalOpened && (
           <PopOver
             popOverData={popOverData}

--- a/frontend/src/app/_components/ui/popover/PopOver.tsx
+++ b/frontend/src/app/_components/ui/popover/PopOver.tsx
@@ -46,8 +46,11 @@ export default function PopOver({
         onKeyDown={(e) =>
           (e.key === 'Esc' /** IE/Edge */ || e.key === 'Escape') && closeModal()
         }
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
       >
-        <ul className="flex flex-col gap-6 justify-center items-center p-4">
+        <ul className="flex flex-col gap-2 justify-center items-center p-2">
           {popOverData &&
             popOverData.map((data, idx) => (
               <PopOverIcon key={idx} data={data} closeModal={closeModal} />

--- a/frontend/src/app/_components/ui/popover/PopOverItem.tsx
+++ b/frontend/src/app/_components/ui/popover/PopOverItem.tsx
@@ -17,7 +17,7 @@ export default function PopOverIcon({ data, closeModal }: TPopOverIcon) {
         closeModal();
         href && push(href);
       }}
-      className="flex items-center gap-x-2 cursor-pointer"
+      className="p-2 flex items-center gap-x-2 cursor-pointer"
     >
       <div>{label}</div>
       {icon}


### PR DESCRIPTION
## Motivation 🧐
#227 및 #247 에 의거하여, FAB와 PopOver를 수정합니다.

## Key Changes 🔑
- 타깃 크기를 고려하여, `PopOverItem`에 padding을 주었습니다.
- PopOver 배경 클릭 시 이벤트가 backdrop에 propagate되어 PopOver가 닫히던 현장을 수정하였습니다.
- FAB의 아이콘을 외부에서 제공할 수 있도록 구조를 변경하였습니다.

## To Reviewers 🙏
- FAB의 아이콘은 `FloatingActionButton` 컴포넌트에서 관리되던 모달의 열림/닫힘 상태 변수 `isModalOpened`와 그 스타일이 강결합되어있는 상태였습니다. 따라서 모달이 열렸을 때와 닫혔을 때 두 가지 경우에 대한 아이콘 및 그 스타일을 지정해주어야 합니다.
- 서버 컴포넌트에서 클라이언트로 함수를 바로 넘겨줄 수 없기 때문에, 함수 컴포넌트 또한 바로 넘겨줄 수 없습니다. 따라서 FAB에 제공하는 icon prop들은 이미 렌더링이 끝난 `ReactElement` 타입이어야 합니다.