### PR TITLE
마이 페이지에 존재하는 select를 기반으로 select 컴포넌트 작성

### DIFF
--- a/frontend/__tests__/Select.test.tsx
+++ b/frontend/__tests__/Select.test.tsx
@@ -1,0 +1,45 @@
+import { sortOptions } from '@/app/_components/mypage/MyPageSelectBtns';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Select from '@/app/_components/ui/select/Select';
+import SelectOption from '@/app/_components/ui/select/SelectOption';
+
+describe('Select Component', () => {
+  const closeModal = vi.fn();
+  const onChangeSortOption = vi.fn();
+
+  it('render selectOption when isSortOpened is true', async () => {
+    render(
+      <Select
+        list={sortOptions}
+        selectOption="최신순"
+        onChangeSelectOption={onChangeSortOption}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('select'));
+    const buttonElement = screen.getAllByRole('button');
+    expect(buttonElement).toHaveLength(3);
+  });
+
+  it('call change sort option function on click', async () => {
+    render(
+      <>
+        <Select
+          list={sortOptions}
+          selectOption="최신순"
+          onChangeSelectOption={onChangeSortOption}
+        />
+        <SelectOption
+          list={sortOptions}
+          onChangeSelectOption={onChangeSortOption}
+          closeModal={closeModal}
+        />
+      </>,
+    );
+
+    const rateButton = await screen.findByRole('button', { name: '별점순' });
+
+    fireEvent.click(rateButton);
+
+    expect(onChangeSortOption).toHaveBeenCalledWith('rate');
+  });
+});

--- a/frontend/__tests__/Select.test.tsx
+++ b/frontend/__tests__/Select.test.tsx
@@ -12,6 +12,9 @@ describe('Select Component', () => {
       <Select
         list={sortOptions}
         selectOption="최신순"
+        selectStyle=""
+        optionStyle=""
+        defaultValue="최신순"
         onChangeSelectOption={onChangeSortOption}
       />,
     );
@@ -26,6 +29,9 @@ describe('Select Component', () => {
         <Select
           list={sortOptions}
           selectOption="최신순"
+          selectStyle=""
+          optionStyle=""
+          defaultValue="최신순"
           onChangeSelectOption={onChangeSortOption}
         />
         <SelectOption

--- a/frontend/public/icons/chevron-down.svg
+++ b/frontend/public/icons/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1.5L6 6.5L11 1.5"  stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/app/_components/mypage/MyPageSelectBtns.tsx
+++ b/frontend/src/app/_components/mypage/MyPageSelectBtns.tsx
@@ -1,5 +1,6 @@
 import { EventFor } from '@/types/type';
 import React, { Dispatch, SetStateAction, useState } from 'react';
+import Select from '../ui/select/Select';
 
 const selectBtns = [
   { label: '전체', value: 'all' },
@@ -7,11 +8,17 @@ const selectBtns = [
   { label: '비공개', value: 'private' },
 ];
 
+const sortOptions = [
+  { label: '최신순', value: 'desc' },
+  { label: '오래된순', value: 'asc' },
+  { label: '별점순', value: 'rate' },
+];
+
 interface TMyPageSelectBtn {
   selectOption: string;
   sortOption: string;
   onClickSelectOption: (option: string) => void;
-  onChangeSortOption: (option: string) => void;
+  onChangeSortOption: (option: string | number) => void;
   onChangeAllList: (
     e: EventFor<'input', 'onChange'>,
     setIsChecked: Dispatch<SetStateAction<boolean>>,
@@ -27,6 +34,7 @@ export default function MyPageSelectBtns({
   onChangeAllList,
 }: TMyPageSelectBtn) {
   const [isChecked, setIsChecked] = useState(false);
+
   return (
     <>
       <ul className="flex items-center gap-x-2">
@@ -47,7 +55,7 @@ export default function MyPageSelectBtns({
           </button>
         ))}
       </ul>
-      <div className="flex justify-between mx-5 mb-2 mt-4">
+      <div className="flex justify-between mx-5 mt-4">
         <div className="flex items-center gap-x-4">
           <input
             type="checkbox"
@@ -57,19 +65,12 @@ export default function MyPageSelectBtns({
           />
           <div>전체 선택</div>
         </div>
-        <select
-          name="sort-option"
-          className="p-2"
-          onChange={(e) => {
-            setIsChecked(false);
-            onChangeSortOption(e.currentTarget.value);
-          }}
-          value={sortOption}
-        >
-          <option value="desc">최신순</option>
-          <option value="asc">오래된순</option>
-          <option value="rate">평점순</option>
-        </select>
+        <Select
+          list={sortOptions}
+          optionStyle={'top-10 left-0 bg-white'}
+          selectOption={sortOption}
+          onChangeSelectOption={onChangeSortOption}
+        />
       </div>
     </>
   );

--- a/frontend/src/app/_components/mypage/MyPageSelectBtns.tsx
+++ b/frontend/src/app/_components/mypage/MyPageSelectBtns.tsx
@@ -8,7 +8,7 @@ const selectBtns = [
   { label: '비공개', value: 'private' },
 ];
 
-const sortOptions = [
+export const sortOptions = [
   { label: '최신순', value: 'desc' },
   { label: '오래된순', value: 'asc' },
   { label: '별점순', value: 'rate' },

--- a/frontend/src/app/_components/mypage/MyPageSelectBtns.tsx
+++ b/frontend/src/app/_components/mypage/MyPageSelectBtns.tsx
@@ -1,6 +1,8 @@
 import { EventFor } from '@/types/type';
 import React, { Dispatch, SetStateAction, useState } from 'react';
+import IconWithCounts from '../IconWithCounts';
 import Select from '../ui/select/Select';
+import StarIcon from '/public/icons/star.svg';
 
 const selectBtns = [
   { label: '전체', value: 'all' },
@@ -11,7 +13,10 @@ const selectBtns = [
 export const sortOptions = [
   { label: '최신순', value: 'desc' },
   { label: '오래된순', value: 'asc' },
-  { label: '별점순', value: 'rate' },
+  {
+    label: '별점순',
+    value: 'rate',
+  },
 ];
 
 interface TMyPageSelectBtn {
@@ -67,9 +72,10 @@ export default function MyPageSelectBtns({
         </div>
         <Select
           list={sortOptions}
-          optionStyle={'top-10 left-0 bg-white'}
+          optionStyle={'top-10 left-0 bg-white w-full mx-auto'}
           selectOption={sortOption}
           onChangeSelectOption={onChangeSortOption}
+          defaultValue="최신순"
         />
       </div>
     </>

--- a/frontend/src/app/_components/mypage/spot/MyPageSpotList.tsx
+++ b/frontend/src/app/_components/mypage/spot/MyPageSpotList.tsx
@@ -147,7 +147,7 @@ export default function MyPageSpotList({
   useEffect(() => {
     setCurrentPage(1);
     getUser(1, divideCount, 'desc', selectOption);
-  }, [selectOption, sortOption]);
+  }, [selectOption]);
 
   // 함수 분리 예정
   const onClickDelete = () => {
@@ -183,7 +183,8 @@ export default function MyPageSpotList({
     setSortOption('desc');
   };
 
-  const onChangeSortOption = (option: string) => {
+  const onChangeSortOption = (option: string | number) => {
+    if (typeof option === 'number') return;
     setAllSpotList([]);
     setSortOption(option);
     setCheckedList([]);
@@ -213,7 +214,7 @@ export default function MyPageSpotList({
 
   return !!placeList.length ? (
     <>
-      <div className="my-4">
+      <div className="mt-4 mb-3">
         <MyPageSelectBtns
           selectOption={selectOption}
           sortOption={sortOption}

--- a/frontend/src/app/_components/mypage/spot/MyPageSpotList.tsx
+++ b/frontend/src/app/_components/mypage/spot/MyPageSpotList.tsx
@@ -214,7 +214,7 @@ export default function MyPageSpotList({
 
   return !!placeList.length ? (
     <>
-      <div className="mt-4 mb-3">
+      <div className="mt-4 mb-3 px-2">
         <MyPageSelectBtns
           selectOption={selectOption}
           sortOption={sortOption}

--- a/frontend/src/app/_components/ui/select/Select.tsx
+++ b/frontend/src/app/_components/ui/select/Select.tsx
@@ -1,3 +1,4 @@
+import { EventFor } from '@/types/type';
 import React, { ReactElement, useEffect, useState } from 'react';
 import SelectOption from './SelectOption';
 import ChevronDownIcon from '/public/icons/chevron-down.svg';
@@ -8,17 +9,28 @@ export default function Select({
   optionStyle,
   selectOption,
   onChangeSelectOption,
+  defaultValue,
+  defaultValueColor,
 }: {
   list: { label: string | ReactElement; value: string | number }[];
   selectStyle?: string;
   optionStyle?: string;
   selectOption: string;
   onChangeSelectOption: (option: string | number) => void;
+  defaultValue: string | ReactElement;
+  defaultValueColor?: string;
 }) {
   const [isSortOpened, setIsSortOpened] = useState(false);
-  const [viewSelectOption, setViewSelectOption] = useState<string | ReactElement | undefined>('최신순');
+  const [viewSelectOption, setViewSelectOption] = useState<
+    string | ReactElement | undefined
+  >(defaultValue);
   const closeModal = () => {
     setIsSortOpened(false);
+  };
+
+  const keyDownHandler = (e: EventFor<'ul', 'onKeyDown'>) => {
+    e.key === 'Enter' && setIsSortOpened(!isSortOpened);
+    e.key === 'Escape' && setIsSortOpened(false);
   };
 
   useEffect(() => {
@@ -33,12 +45,18 @@ export default function Select({
         selectStyle && selectStyle
       } rounded-md cursor-pointer relative`}
       onClick={() => setIsSortOpened(!isSortOpened)}
-      onKeyDown={(e) => e.key === 'Enter' && setIsSortOpened(!isSortOpened)}
+      onKeyDown={(e) => keyDownHandler(e)}
       aria-label="select"
     >
-      <div className="flex items-center justify-between p-2 gap-x-4 text-main font-semibold">
+      <div
+        className={`flex items-center justify-between p-2 gap-x-4 ${
+          defaultValueColor ? defaultValueColor : 'text-gray-700'
+        }`}
+      >
         {viewSelectOption}
-        <ChevronDownIcon className="w-4 h-2 stroke-gray-500" />
+        <ChevronDownIcon
+          className={`w-4 h-2 stroke-gray-500 ${isSortOpened && 'rotate-180'} `}
+        />
       </div>
       {isSortOpened && (
         <SelectOption

--- a/frontend/src/app/_components/ui/select/Select.tsx
+++ b/frontend/src/app/_components/ui/select/Select.tsx
@@ -1,0 +1,52 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import SelectOption from './SelectOption';
+import ChevronDownIcon from '/public/icons/chevron-down.svg';
+
+export default function Select({
+  list,
+  selectStyle,
+  optionStyle,
+  selectOption,
+  onChangeSelectOption,
+}: {
+  list: { label: string | ReactElement; value: string | number }[];
+  selectStyle?: string;
+  optionStyle?: string;
+  selectOption: string;
+  onChangeSelectOption: (option: string | number) => void;
+}) {
+  const [isSortOpened, setIsSortOpened] = useState(false);
+  const [viewSelectOption, setViewSelectOption] = useState<string | ReactElement | undefined>('최신순');
+  const closeModal = () => {
+    setIsSortOpened(false);
+  };
+
+  useEffect(() => {
+    const selectedLabel = list.find((item) => item.value === selectOption);
+    setViewSelectOption(selectedLabel?.label);
+  }, [selectOption]);
+
+  return (
+    <ul
+      tabIndex={0}
+      className={`${
+        selectStyle && selectStyle
+      } rounded-md cursor-pointer relative`}
+      onClick={() => setIsSortOpened(!isSortOpened)}
+      onKeyDown={(e) => e.key === 'Enter' && setIsSortOpened(!isSortOpened)}
+    >
+      <div className="flex items-center justify-between p-2 gap-x-4 text-main font-semibold">
+        {viewSelectOption}
+        <ChevronDownIcon className="w-4 h-2 stroke-gray-500" />
+      </div>
+      {isSortOpened && (
+        <SelectOption
+          list={list}
+          optionStyle={optionStyle}
+          onChangeSelectOption={onChangeSelectOption}
+          closeModal={closeModal}
+        />
+      )}
+    </ul>
+  );
+}

--- a/frontend/src/app/_components/ui/select/Select.tsx
+++ b/frontend/src/app/_components/ui/select/Select.tsx
@@ -34,6 +34,7 @@ export default function Select({
       } rounded-md cursor-pointer relative`}
       onClick={() => setIsSortOpened(!isSortOpened)}
       onKeyDown={(e) => e.key === 'Enter' && setIsSortOpened(!isSortOpened)}
+      aria-label="select"
     >
       <div className="flex items-center justify-between p-2 gap-x-4 text-main font-semibold">
         {viewSelectOption}

--- a/frontend/src/app/_components/ui/select/SelectOption.tsx
+++ b/frontend/src/app/_components/ui/select/SelectOption.tsx
@@ -44,7 +44,7 @@ export default function SelectOption({
           <button
             key={value}
             value={value}
-            className="cursor-pointer text-gray-700 py-[5px]"
+            className="cursor-pointer text-gray-700 py-[5px] flex justify-center"
             onClick={(e) => onChangeSelectOption(e.currentTarget.value)}
             onKeyDown={(e) =>
               e.key === 'Enter' && onChangeSelectOption(e.currentTarget.value)

--- a/frontend/src/app/_components/ui/select/SelectOption.tsx
+++ b/frontend/src/app/_components/ui/select/SelectOption.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement, useEffect } from 'react';
+
+export default function SelectOption({
+  list,
+  optionStyle,
+  onChangeSelectOption,
+  closeModal,
+}: {
+  list: { value: string | number; label: string | ReactElement }[];
+  optionStyle?: string;
+  onChangeSelectOption: (option: string | number) => void;
+  closeModal: () => void;
+}) {
+  const mouseEventPrevent = (e: Event) => {
+    e.preventDefault();
+  };
+  const keyBoardArrowPrevent = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') e.preventDefault();
+  };
+  useEffect(() => {
+    window.addEventListener('DOMMouseScroll', mouseEventPrevent, false); // older FF
+    window.addEventListener('wheel', mouseEventPrevent, { passive: false }); // modern desktop
+    window.addEventListener('touchmove', mouseEventPrevent, { passive: false }); // mobile
+    window.addEventListener('keydown', keyBoardArrowPrevent);
+    return () => {
+      window.removeEventListener('DOMMouseScroll', mouseEventPrevent, false);
+      window.removeEventListener('wheel', mouseEventPrevent, false);
+      window.removeEventListener('touchmove', mouseEventPrevent);
+      window.removeEventListener('keydown', keyBoardArrowPrevent);
+    };
+  }, []);
+  return (
+    <>
+      <div
+        className={`fixed inset-0 max-w-[430px] mx-auto z-20 cursor-default`}
+        onClick={closeModal}
+      ></div>
+      <div
+        className={`flex flex-col w-full absolute ${
+          optionStyle ? optionStyle : 'top-10 left-0 bg-white'
+        } border py-1 rounded-md z-30`}
+      >
+        {list.map(({ label, value }) => (
+          <button
+            key={value}
+            value={value}
+            className="cursor-pointer text-gray-700 py-[5px]"
+            onClick={(e) => onChangeSelectOption(e.currentTarget.value)}
+            onKeyDown={(e) =>
+              e.key === 'Enter' && onChangeSelectOption(e.currentTarget.value)
+            }
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Motivation 🧐
#282 이슈를 바탕으로 select 컴포넌트를 작성했습니다.
공통 컴포넌트인 `viewPortal`를 이용해서 구현하려고 했으나 `option` 을 렌더링 하는 `<SelectOption />` 컴포넌트가 부모 컴포넌트인 `<Select/>` 태그에 종속되지 않고 백드롭에 종속되는 문제가 있었습니다.
이 전에 작성했던 FAB 버튼은 fixed로 정확히 위치가 정해져 있었어서 하위 컴포넌트도 문제 없이 사용할 수 있었는데 select 같은 경우는 어디에 위치할 지 모르기 때문에 `viewPortal`을 사용하지 않고 작성했습니다.
<br>

## Key Changes 🔑

<br>

## To Reviewers 🙏
`ViewPortal` 컴포넌트를 사용하지 않고 select 컴포넌트를 작성했습니다.
나중에 리팩토링 할 때 `ViewPortal`을 사용할 수 있게 구조 변경을 고민해 볼 필요가 있을 것 같습니다.
