### PR TITLE
hotfix: 로그인 후 헤더 레이아웃에서 api 호출 시 에러 나는 현상 수정

### DIFF
--- a/frontend/src/app/(with-header)/layout.tsx
+++ b/frontend/src/app/(with-header)/layout.tsx
@@ -8,11 +8,9 @@ export default async function WithHeaderLayout({
 }: {
   children: ReactNode;
 }) {
-  const memberInfo = await authenticateUser();
-
   return (
     <section className="w-full h-full flex flex-col">
-      <Header memberInfo={memberInfo?.code ? null : memberInfo} />
+      <Header />
       {children}
     </section>
   );

--- a/frontend/src/app/_components/header/Header.tsx
+++ b/frontend/src/app/_components/header/Header.tsx
@@ -3,14 +3,10 @@ import HeaderClient from './HeaderClient';
 import { Session } from 'next-auth';
 import { TUserInfo } from '../mypage/types';
 
-export default function Header({
-  memberInfo,
-}: {
-  memberInfo: TUserInfo | null;
-}) {
+export default function Header() {
   return (
     <div className="w-full py-4 flex justify-between items-center sticky top-0 bg-main z-10">
-      <HeaderClient memberInfo={memberInfo} />
+      <HeaderClient />
     </div>
   );
 }

--- a/frontend/src/app/endpoints/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/endpoints/api/auth/[...nextauth]/route.ts
@@ -59,7 +59,12 @@ const handler = NextAuth({
   },
   events: {
     signOut: async () => {
-      const res = await requestWithCookie('logout')()()()();
+      const res = await fetch('https://yigil.co.kr/api/v1/signout', {
+        method: 'GET',
+        headers: {
+          Cookie: `SESSION=${cookies().get('SESSION')?.value}`,
+        },
+      });
       if (res) cookies().set('SESSION', '');
     },
   },

--- a/frontend/src/mocks/api/myPage.ts
+++ b/frontend/src/mocks/api/myPage.ts
@@ -12,7 +12,7 @@ const handlers = [
     } else {
       return HttpResponse.json({
         status: 400,
-        code: 9999,
+        code: 9201,
       });
     }
   }),


### PR DESCRIPTION
## Motivation 🧐
유저 검증 api 를 `layout` 파일 호출 -> 클라이언트 호출로 변경
로그인 에러로 잘 동작하지 않는 부분이 있어 급하게 수정 후 pr 날립니다.
<br>

## Key Changes 🔑

<br>

## To Reviewers 🙏
저는 로그인 후 쿠키를 브라우저에 저장시키고 다시 불러와서 사용하는 타이밍이 저장되는 타이밍보다 빠른 것으로 예상합니다.
예상되는 다른 의견 있으시면 댓글 남겨 주세용
