### PR TITLE
잘못 들어간 search param 구분자 제거

### DIFF
--- a/frontend/src/app/_components/api/httpRequest.ts
+++ b/frontend/src/app/_components/api/httpRequest.ts
@@ -22,7 +22,7 @@ export const requestWithoutCookie =
   (headers: Record<string, string> = headerInitOption) =>
   async (errorMsg: string = '요청에 실패했습니다') => {
     try {
-      const res = await fetch(`${BASE_URL}/v1/${url}?${params}`, {
+      const res = await fetch(`${BASE_URL}/v1/${url}${params}`, {
         method,
         headers: {
           ...headerInitOption,
@@ -48,7 +48,7 @@ export const requestWithCookie =
     const cookie = cookies().get('SESSION')?.value;
 
     try {
-      const res = await fetch(`${BASE_URL}/v1/${url}?${params}`, {
+      const res = await fetch(`${BASE_URL}/v1/${url}${params}`, {
         method,
         headers: {
           ...headerInitOption,


### PR DESCRIPTION
## Motivation 🧐
#298 을 처리하는 과정에서 생긴 오류를 수정합니다.

## Key Changes 🔑
- `requestWithCookie`, `requestWithoutCookie`에 잘못 들어간 search param 구분자 `?`을 제거합니다.

## To Reviewers 🙏
어제 코드 작성하면서 약간 혼동이 와서 잘못 기입했는데, 오늘 mock api를 돌려보며 발견했습니다. 빠르게 처리 부탁드립니다~