### PR TITLE
장소 추가 시 지도에서 장소를 선택하지 않아도 다음으로 넘어갈 수 있던 현상 수정

### DIFF
--- a/frontend/src/app/_components/add/AddSpot.tsx
+++ b/frontend/src/app/_components/add/AddSpot.tsx
@@ -51,7 +51,10 @@ function canGoNext(
 ) {
   const label = step.data.label;
 
-  if (label === '시작' && currentFoundPlace === undefined) {
+  if (
+    label === '시작' &&
+    (currentFoundPlace === undefined || addSpotState.name === '')
+  ) {
     return false;
   }
 


### PR DESCRIPTION
## Motivation 🧐
이전 코드에서는 장소 추가 플로우에서 검색 없이 다음으로 넘어가려 하는 경우만 막았었는데, 사용자가 검색 후 검색 결과에서 장소명을 클릭해 지도에 장소 마커가 표시된 이후 선택 없이 다음으로 넘어갈 수 있는 오류가 있어, 이를 수정합니다.

## Key Changes 🔑
장소 추가를 위해 최상위에서 관리되는 `AddSpotProps`의 name이 빈 문자열인 경우 다음으로 넘어가지 않도록 합니다.

## To Reviewers 🙏
