### PR TITLE
hotfix : membr profile 이미지가 잘못 전달되는 문제 

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/member/Member.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/member/Member.java
@@ -138,7 +138,7 @@ public class Member {
 
     public String getProfileImageUrl() {
         if(profileImageUrl == null) return null;
-        if(profileImageUrl.startsWith("http://")) return profileImageUrl;
+        if(profileImageUrl.startsWith("http://") || profileImageUrl.startsWith("https://")) return profileImageUrl;
         else return DEFAULT_PROFILE_CDN + profileImageUrl;
     }
 


### PR DESCRIPTION
## Motivation 🧐
프로필 이미지 url을 잘못 전달하는 문제가 있어서 수정하였습니다.
<br>

## Key Changes 🔑

<br>

## To Reviewers 🙏
