### PR TITLE
`ENVIRONMENT` 환경변수 제거 및 `getBaseUrl` 사용 통일

### DIFF
--- a/frontend/src/app/(with-header)/(home)/action.ts
+++ b/frontend/src/app/(with-header)/(home)/action.ts
@@ -5,7 +5,6 @@ import z from 'zod';
 import { cookies } from 'next/headers';
 import { placeSchema, regionSchema } from '@/types/response';
 import { getBaseUrl } from '@/app/utilActions';
-import { revalidateTag } from 'next/cache';
 
 const placeResponseSchema = z.object({
   places: z.array(placeSchema),

--- a/frontend/src/app/(with-header)/place/action.ts
+++ b/frontend/src/app/(with-header)/place/action.ts
@@ -1,16 +1,15 @@
 'use server';
 
-import { mySpotForPlaceSchema, placeDetailSchema } from '@/types/response';
 import { cookies } from 'next/headers';
+import { getBaseUrl } from '@/app/utilActions';
+import { mySpotForPlaceSchema, placeDetailSchema } from '@/types/response';
 
 async function fetchPlaceDetail(id: number) {
   const session = cookies().get('SESSION')?.value;
 
-  const { BASE_URL, DEV_BASE_URL, ENVIRONMENT } = process.env;
+  const BASE_URL = await getBaseUrl();
 
-  const baseUrl = ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
-
-  const response = await fetch(`${baseUrl}/v1/places/${id}`, {
+  const response = await fetch(`${BASE_URL}/v1/places/${id}`, {
     headers: {
       Cookies: `SESSION=${session}`,
     },
@@ -22,11 +21,9 @@ async function fetchPlaceDetail(id: number) {
 async function fetchMySpotForPlace(id: number) {
   const session = cookies().get('SESSION')?.value;
 
-  const { BASE_URL, DEV_BASE_URL, ENVIRONMENT } = process.env;
+  const BASE_URL = await getBaseUrl();
 
-  const baseUrl = ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
-
-  const response = await fetch(`${baseUrl}/v1/spots/place/${id}/me`, {
+  const response = await fetch(`${BASE_URL}/v1/spots/place/${id}/me`, {
     headers: {
       Cookie: `SESSION=${session}`,
     },

--- a/frontend/src/app/_components/add/common/action.ts
+++ b/frontend/src/app/_components/add/common/action.ts
@@ -18,6 +18,7 @@ import {
 
 import type { TAddSpotProps } from '../spot/SpotContext';
 import { revalidateTag } from 'next/cache';
+import { getBaseUrl } from '@/app/utilActions';
 
 function staticMapUrl(
   width: number,
@@ -38,13 +39,12 @@ function staticMapUrl(
 async function getStaticMapUrlFromBackend(name: string, address: string) {
   const cookie = cookies().get('SESSION')?.value;
 
-  const { BASE_URL, DEV_BASE_URL, ENVIRONMENT } = process.env;
-  const baseUrl = ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
+  const BASE_URL = await getBaseUrl();
 
   const queryParams = `name=${name}&address=${address}`;
 
   const response = await fetch(
-    `${baseUrl}/v1/places/static-image?${queryParams}`,
+    `${BASE_URL}/v1/places/static-image?${queryParams}`,
     {
       headers: {
         Cookie: `SESSION=${cookie}`,
@@ -145,13 +145,11 @@ export async function postSpotData(state: TAddSpotProps) {
 
   const formData = await parseAddSpotProps(state);
 
-  const { ENVIRONMENT, BASE_URL, DEV_BASE_URL } = process.env;
-
-  const baseUrl = ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
+  const BASE_URL = await getBaseUrl();
 
   // Next.js fetch form은 'Content-Type': 'multipart/form-data를
   // 직접 명시하면 Boundary 설정이 어긋나 제대로 동작하지 않음
-  const response = await fetch(`${baseUrl}/v1/spots`, {
+  const response = await fetch(`${BASE_URL}/v1/spots`, {
     method: 'POST',
     body: formData,
     headers: {

--- a/frontend/src/app/_components/api/action.ts
+++ b/frontend/src/app/_components/api/action.ts
@@ -3,8 +3,7 @@
 import { z } from 'zod';
 import { cookies } from 'next/headers';
 import { requestWithCookie } from './httpRequest';
-import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
+import { getBaseUrl } from '@/app/utilActions';
 
 export async function logout() {
   const response = await requestWithCookie('logout')()()()(
@@ -34,14 +33,12 @@ export async function backendLoginRequest(data: {
   provider: string;
   accessToken: string;
 }) {
-  const { ENVIRONMENT, BASE_URL, DEV_BASE_URL } = process.env;
-
-  const baseUrl = ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
+  const BASE_URL = await getBaseUrl();
 
   const { id, nickname, profile_image_url, email, provider, accessToken } =
     data;
 
-  return fetch(`${baseUrl}/v1/login`, {
+  return fetch(`${BASE_URL}/v1/login`, {
     method: 'POST',
     body: JSON.stringify({
       id,

--- a/frontend/src/app/_components/mypage/hooks/authenticateUser.ts
+++ b/frontend/src/app/_components/mypage/hooks/authenticateUser.ts
@@ -1,14 +1,17 @@
 'use server';
+
 import { cookies } from 'next/headers';
-const { ENVIRONMENT, BASE_URL, DEV_BASE_URL } = process.env;
-const baseUrl = ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
+import { getBaseUrl } from '@/app/utilActions';
 
 export const authenticateUser = async () => {
+  const BASE_URL = await getBaseUrl();
   const cookie = cookies().get('SESSION')?.value;
-  const res = await fetch(`${baseUrl}/v1/members`, {
+
+  const res = await fetch(`${BASE_URL}/v1/members`, {
     headers: {
       Cookie: `SESSION=${cookie}`,
     },
   });
+
   return res.json();
 };

--- a/frontend/src/app/endpoints/api/auth/callback/google/route.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/google/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, ENVIRONMENT } = process.env;
+  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, NODE_ENV } = process.env;
 
   const redirectUri = await googldRedirectUri();
 
@@ -76,7 +76,7 @@ export async function GET(request: NextRequest) {
   response.cookies.set({
     name: key,
     value,
-    secure: ENVIRONMENT === 'production',
+    secure: NODE_ENV === 'production',
   });
 
   return response;

--- a/frontend/src/app/endpoints/api/auth/callback/kakao/constants.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/kakao/constants.ts
@@ -2,12 +2,11 @@ export const KAKAO_BASE_URL = 'https://kapi.kakao.com';
 export const KAKAO_AUTH_BASE_URL = 'https://kauth.kakao.com';
 
 export async function getCallbackUrlBase() {
-  const { ENVIRONMENT, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } =
-    process.env;
+  const { NODE_ENV, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } = process.env;
 
-  return ENVIRONMENT === 'production'
+  return NODE_ENV === 'production'
     ? PRODUCTION_FRONTEND_URL
-    : ENVIRONMENT === 'dev'
+    : NODE_ENV === 'development'
     ? DEV_FRONTEND_URL
     : 'http://localhost:3000';
 }

--- a/frontend/src/app/endpoints/api/auth/callback/kakao/route.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/kakao/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const { KAKAO_ID, KAKAO_SECRET, ENVIRONMENT } = process.env;
+  const { KAKAO_ID, KAKAO_SECRET, NODE_ENV } = process.env;
 
   const redirectUri = await kakaoRedrectUri();
 
@@ -100,7 +100,7 @@ export async function GET(request: NextRequest) {
   response.cookies.set({
     name: key,
     value,
-    secure: ENVIRONMENT === 'production',
+    secure: NODE_ENV === 'production',
   });
 
   return response;

--- a/frontend/src/app/utilActions.ts
+++ b/frontend/src/app/utilActions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 export async function getBaseUrl() {
-  const { BASE_URL, DEV_BASE_URL, ENVIRONMENT } = process.env;
+  const { BASE_URL, DEV_BASE_URL, NODE_ENV } = process.env;
 
-  return ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
+  return NODE_ENV === 'production' ? BASE_URL : DEV_BASE_URL;
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -5,13 +5,12 @@ import { myInfoSchema } from './types/response';
 const restricted = ['/add', '/mypage'];
 
 export default async function middleware(request: NextRequest) {
-  const { ENVIRONMENT, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } =
-    process.env;
+  const { NODE_ENV, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } = process.env;
 
   const baseUrl =
-    ENVIRONMENT === 'production'
+    NODE_ENV === 'production'
       ? PRODUCTION_FRONTEND_URL
-      : ENVIRONMENT === 'dev'
+      : NODE_ENV === 'development'
       ? DEV_FRONTEND_URL
       : 'http://localhost:3000';
 
@@ -43,7 +42,7 @@ export default async function middleware(request: NextRequest) {
       name: session.name,
       value: session.value,
       httpOnly: true,
-      secure: ENVIRONMENT === 'production',
+      secure: NODE_ENV === 'production',
       sameSite: 'strict',
     });
 

--- a/frontend/src/types/type.d.ts
+++ b/frontend/src/types/type.d.ts
@@ -22,10 +22,11 @@ declare global {
       MAP_SECRET: string;
 
       DEV_BASE_URL: string;
-      ENVIRONMENT: string;
 
       PRODUCTION_FRONTEND_URL: string;
       DEV_FRONTEND_URL: string;
+
+      ENVIRONMENT: string;
     }
   }
 }


### PR DESCRIPTION
## Motivation 🧐
- Node 환경에서 개발 환경을 나타내기 위해 일반적으로 `NODE_ENV` 환경 변수가 사용됩니다. 추가적인 환경 변수 사용을 피하기 위해, 기존에 `ENVIRONMENT` 환경 변수를 사용하던 코드를 `NODE_ENV`를 사용하도록 변경하였습니다.
- API 엔드포인트를 만들기 위해 BASE_URL을 얻어오는 과정이 매번 중복되어 해당 과정을 서버 액션 `getBaseUrl()`로 분리한 바 있습니다. 해당 코드를 사용하도록 통일합니다.

## Key Changes 🔑
`httpRequest.ts`와 `myPageAction.ts` 관련 파일들은 서로 얽혀있는 것들이 많아, @davidktlee 님께서 정리해주실 필요가 있습니다. 따라서 `ENVIRONMENT` 환경 변수 타입 삭제는 잠시 유보하며, @davidktlee 님께서 관련 작업을 완료하신 후 함께 삭제해주시면 감사하겠습니다.

## To Reviewers 🙏
