### PR TITLE
동작에 필요한 별도 환경 변수 복구

### DIFF
--- a/frontend/src/app/endpoints/api/auth/callback/google/route.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/google/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, NODE_ENV } = process.env;
+  const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, ENVIRONMENT } = process.env;
 
   const redirectUri = await googldRedirectUri();
 
@@ -76,7 +76,7 @@ export async function GET(request: NextRequest) {
   response.cookies.set({
     name: key,
     value,
-    secure: NODE_ENV === 'production',
+    secure: ENVIRONMENT === 'production',
   });
 
   return response;

--- a/frontend/src/app/endpoints/api/auth/callback/kakao/constants.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/kakao/constants.ts
@@ -2,11 +2,12 @@ export const KAKAO_BASE_URL = 'https://kapi.kakao.com';
 export const KAKAO_AUTH_BASE_URL = 'https://kauth.kakao.com';
 
 export async function getCallbackUrlBase() {
-  const { NODE_ENV, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } = process.env;
+  const { ENVIRONMENT, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } =
+    process.env;
 
-  return NODE_ENV === 'production'
+  return ENVIRONMENT === 'production'
     ? PRODUCTION_FRONTEND_URL
-    : NODE_ENV === 'development'
+    : ENVIRONMENT === 'development'
     ? DEV_FRONTEND_URL
     : 'http://localhost:3000';
 }

--- a/frontend/src/app/endpoints/api/auth/callback/kakao/route.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/kakao/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const { KAKAO_ID, KAKAO_SECRET, NODE_ENV } = process.env;
+  const { KAKAO_ID, KAKAO_SECRET, ENVIRONMENT } = process.env;
 
   const redirectUri = await kakaoRedrectUri();
 
@@ -100,7 +100,7 @@ export async function GET(request: NextRequest) {
   response.cookies.set({
     name: key,
     value,
-    secure: NODE_ENV === 'production',
+    secure: ENVIRONMENT === 'production',
   });
 
   return response;

--- a/frontend/src/app/utilActions.ts
+++ b/frontend/src/app/utilActions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 export async function getBaseUrl() {
-  const { BASE_URL, DEV_BASE_URL, NODE_ENV } = process.env;
+  const { BASE_URL, DEV_BASE_URL, ENVIRONMENT } = process.env;
 
-  return NODE_ENV === 'production' ? BASE_URL : DEV_BASE_URL;
+  return ENVIRONMENT === 'production' ? BASE_URL : DEV_BASE_URL;
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -5,12 +5,13 @@ import { myInfoSchema } from './types/response';
 const restricted = ['/add', '/mypage'];
 
 export default async function middleware(request: NextRequest) {
-  const { NODE_ENV, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } = process.env;
+  const { ENVIRONMENT, PRODUCTION_FRONTEND_URL, DEV_FRONTEND_URL } =
+    process.env;
 
   const baseUrl =
-    NODE_ENV === 'production'
+    ENVIRONMENT === 'production'
       ? PRODUCTION_FRONTEND_URL
-      : NODE_ENV === 'development'
+      : ENVIRONMENT === 'development'
       ? DEV_FRONTEND_URL
       : 'http://localhost:3000';
 
@@ -42,7 +43,7 @@ export default async function middleware(request: NextRequest) {
       name: session.name,
       value: session.value,
       httpOnly: true,
-      secure: NODE_ENV === 'production',
+      secure: ENVIRONMENT === 'production',
       sameSite: 'strict',
     });
 

--- a/frontend/src/types/type.d.ts
+++ b/frontend/src/types/type.d.ts
@@ -26,7 +26,7 @@ declare global {
       PRODUCTION_FRONTEND_URL: string;
       DEV_FRONTEND_URL: string;
 
-      ENVIRONMENT: string;
+      ENVIRONMENT: 'production' | 'development' | 'local';
     }
   }
 }


### PR DESCRIPTION
## Motivation 🧐
#419 에서 `ENVIRONMENT` 환경 변수를 의존을 제거한 바 있습니다. 이 이유는 `NODE_ENV` 환경변수를 통해 API 백엔드 및 프론트엔드 도메인을 효과적으로 관리할 수 있다고 생각했기 때문입니다. 그러나 `NODE_ENV` 환경변수는 `production`, `development` 두 가지의 값만을 일반적으로 가질 수 있는 것으로 보입니다. `test`라는 값을 가질 수 있어 괜찮지 않나 생각했지만, `test`는 테스트 러너에서 실행될 때만 들어가는 값이었습니다... 따라서 환경 변수의 사용을 원래대로 복구합니다.

## Key Changes 🔑
- `NODE_ENV`를 사용하도록 변경한 부분을 다시 `ENVIRONMENT` 환경 변수를 사용하도록 원상 복구합니다.

## To Reviewers 🙏
