### PR TITLE
488 query dsl

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/CourseListDto.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/CourseListDto.java
@@ -1,0 +1,29 @@
+package kr.co.yigil.travel.domain.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class CourseListDto {
+
+    private final Long courseId;
+    private final String title;
+    private final Double rate;
+    private final String mapStaticImageUrl;
+    private final Integer spotCount;
+    private final LocalDateTime createdDate;
+    private final Boolean isPrivate;
+
+    @QueryProjection
+    public CourseListDto(Long courseId, String title, Double rate, String mapStaticImageUrl,
+        Integer spotCount, LocalDateTime createdDate, Boolean isPrivate) {
+        this.courseId = courseId;
+        this.title = title;
+        this.rate = rate;
+        this.mapStaticImageUrl = mapStaticImageUrl;
+        this.spotCount = spotCount;
+        this.createdDate = createdDate;
+        this.isPrivate = isPrivate;
+    }
+}

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/SpotListDto.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/SpotListDto.java
@@ -1,0 +1,30 @@
+package kr.co.yigil.travel.domain.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class SpotListDto {
+
+    private final Long spotId;
+    private final Long placeId;
+    private final String title;
+    private final double rate;
+    private final String imageUrl;
+    private final LocalDateTime createdDate;
+    private final Boolean isPrivate;
+
+    @QueryProjection
+    public SpotListDto(Long spotId, Long placeId, String title, double rate, String imageUrl,
+        LocalDateTime createdDate, Boolean isPrivate) {
+        this.spotId = spotId;
+        this.placeId = placeId;
+        this.title = title;
+        this.rate = rate;
+        this.imageUrl = imageUrl;
+        this.createdDate = createdDate;
+        this.isPrivate = isPrivate;
+    }
+
+}

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/infrastructure/CourseQueryDslRepository.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/infrastructure/CourseQueryDslRepository.java
@@ -12,8 +12,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
 import java.util.List;
 import kr.co.yigil.global.Selected;
-import kr.co.yigil.travel.domain.Course;
 import kr.co.yigil.travel.domain.QCourse;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
+import kr.co.yigil.travel.domain.dto.QCourseListDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,7 +28,7 @@ public class CourseQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Page<Course> findAllByMemberIdAndIsPrivate(Long memberId, Selected visibility,
+    public Page<CourseListDto> findAllByMemberIdAndIsPrivate(Long memberId, Selected visibility,
         Pageable pageable) {
         QCourse course = QCourse.course;
         BooleanBuilder builder = new BooleanBuilder();
@@ -48,7 +49,18 @@ public class CourseQueryDslRepository {
         Predicate predicate = builder.getValue();
         List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(pageable.getSort());
 
-        List<Course> courses = jpaQueryFactory.select(course)
+        List<CourseListDto> courses = jpaQueryFactory
+            .select(
+                new QCourseListDto(
+                    course.id,
+                    course.title,
+                    course.rate,
+                    course.mapStaticImageFile.fileUrl,
+                    course.spots.size(),
+                    course.createdAt,
+                    course.isPrivate
+                )
+            )
             .from(course)
             .where(predicate)
             .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/infrastructure/SpotQueryDslRepository.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/infrastructure/SpotQueryDslRepository.java
@@ -13,7 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import kr.co.yigil.global.Selected;
 import kr.co.yigil.travel.domain.QSpot;
-import kr.co.yigil.travel.domain.Spot;
+import kr.co.yigil.travel.domain.dto.QSpotListDto;
+import kr.co.yigil.travel.domain.dto.SpotListDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -26,7 +27,7 @@ import org.springframework.stereotype.Repository;
 public class SpotQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
-    public Page<Spot> findAllByMemberIdAndIsPrivate(Long memberId, Selected visibility, Pageable pageable) {
+    public Page<SpotListDto> findAllByMemberIdAndIsPrivate(Long memberId, Selected visibility, Pageable pageable) {
         QSpot spot = QSpot.spot;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -47,7 +48,18 @@ public class SpotQueryDslRepository {
         Predicate predicate = builder.getValue();
         List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(pageable.getSort());
 
-        List<Spot> spots = jpaQueryFactory.select(spot)
+        List<SpotListDto> spots = jpaQueryFactory
+            .select(
+                new QSpotListDto(
+                    spot.id,
+                    spot.place.id,
+                    spot.title,
+                    spot.rate,
+                    spot.place.imageFile.fileUrl,
+                    spot.createdAt,
+                    spot.isPrivate
+                )
+            )
             .from(spot)
             .where(predicate)
             .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
@@ -60,7 +72,6 @@ public class SpotQueryDslRepository {
             .fetchCount();
 
         return new PageImpl<>(spots, pageable, total);
-
     }
 
     private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort){

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/bookmark/interfaces/dto/mapper/BookmarkMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/bookmark/interfaces/dto/mapper/BookmarkMapperImpl.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class BookmarkMapperImpl implements BookmarkMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/comment/interfaces/dto/mapper/CommentMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/comment/interfaces/dto/mapper/CommentMapperImpl.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class CommentMapperImpl implements CommentMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/favor/interfaces/dto/mapper/FavorMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/favor/interfaces/dto/mapper/FavorMapperImpl.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class FavorMapperImpl implements FavorMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/follow/interfaces/dto/FollowDtoMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/follow/interfaces/dto/FollowDtoMapperImpl.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-05T14:42:07+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class FollowDtoMapperImpl implements FollowDtoMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/login/interfaces/dto/mapper/LoginMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/login/interfaces/dto/mapper/LoginMapperImpl.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class LoginMapperImpl implements LoginMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/member/interfaces/dto/mapper/MemberDtoMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/member/interfaces/dto/mapper/MemberDtoMapperImpl.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-08T23:30:40+0900",
+    date = "2024-03-11T22:46:01+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
@@ -48,6 +48,8 @@ public class MemberDtoMapperImpl implements MemberDtoMapper {
         main1.email( main.getEmail() );
         main1.nickname( main.getNickname() );
         main1.profileImageUrl( main.getProfileImageUrl() );
+        main1.age( main.getAge() );
+        main1.gender( main.getGender() );
         main1.favoriteRegions( favoriteRegionInfoListToFavoriteRegionList( main.getFavoriteRegions() ) );
         main1.followingCount( main.getFollowingCount() );
         main1.followerCount( main.getFollowerCount() );

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/notification/interfaces/dto/mapper/NotificationMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/notification/interfaces/dto/mapper/NotificationMapperImpl.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class NotificationMapperImpl implements NotificationMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/place/interfaces/dto/mapper/PlaceMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/place/interfaces/dto/mapper/PlaceMapperImpl.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-09T21:52:28+0900",
+    date = "2024-03-11T15:38:21+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/region/interfaces/dto/mapper/RegionMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/region/interfaces/dto/mapper/RegionMapperImpl.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class RegionMapperImpl implements RegionMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/CourseMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/CourseMapperImpl.java
@@ -1,5 +1,6 @@
 package kr.co.yigil.travel.interfaces.dto.mapper;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,20 +10,22 @@ import kr.co.yigil.travel.domain.course.CourseCommand;
 import kr.co.yigil.travel.domain.course.CourseInfo;
 import kr.co.yigil.travel.domain.spot.SpotCommand;
 import kr.co.yigil.travel.interfaces.dto.CourseDetailInfoDto;
+import kr.co.yigil.travel.interfaces.dto.CourseDto;
 import kr.co.yigil.travel.interfaces.dto.CourseInfoDto;
 import kr.co.yigil.travel.interfaces.dto.request.CourseRegisterRequest;
 import kr.co.yigil.travel.interfaces.dto.request.CourseRegisterWithoutSeriesRequest;
 import kr.co.yigil.travel.interfaces.dto.request.CourseUpdateRequest;
 import kr.co.yigil.travel.interfaces.dto.request.SpotRegisterRequest;
 import kr.co.yigil.travel.interfaces.dto.request.SpotUpdateRequest;
+import kr.co.yigil.travel.interfaces.dto.response.CourseSearchResponse;
 import kr.co.yigil.travel.interfaces.dto.response.MyCoursesResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class CourseMapperImpl implements CourseMapper {
@@ -184,6 +187,54 @@ public class CourseMapperImpl implements CourseMapper {
         return courseInfo.build();
     }
 
+    @Override
+    public CourseSearchResponse toCourseSearchResponse(CourseInfo.Slice slice) {
+        if ( slice == null ) {
+            return null;
+        }
+
+        List<CourseDto> courses = null;
+        boolean hasNext = false;
+
+        courses = courseSearchInfoListToCourseDtoList( slice.getCourses() );
+        hasNext = slice.isHasNext();
+
+        CourseSearchResponse courseSearchResponse = new CourseSearchResponse( courses, hasNext );
+
+        return courseSearchResponse;
+    }
+
+    @Override
+    public CourseDto toCourseDto(CourseInfo.CourseSearchInfo courseSearchInfo) {
+        if ( courseSearchInfo == null ) {
+            return null;
+        }
+
+        LocalDateTime createDate = null;
+        Long id = null;
+        String title = null;
+        String mapStaticImageUrl = null;
+        String ownerProfileImageUrl = null;
+        String ownerNickname = null;
+        int spotCount = 0;
+        double rate = 0.0d;
+        boolean liked = false;
+
+        createDate = courseSearchInfo.getCreateDate();
+        id = courseSearchInfo.getId();
+        title = courseSearchInfo.getTitle();
+        mapStaticImageUrl = courseSearchInfo.getMapStaticImageUrl();
+        ownerProfileImageUrl = courseSearchInfo.getOwnerProfileImageUrl();
+        ownerNickname = courseSearchInfo.getOwnerNickname();
+        spotCount = courseSearchInfo.getSpotCount();
+        rate = courseSearchInfo.getRate();
+        liked = courseSearchInfo.isLiked();
+
+        CourseDto courseDto = new CourseDto( id, title, mapStaticImageUrl, ownerProfileImageUrl, ownerNickname, spotCount, rate, liked, createDate );
+
+        return courseDto;
+    }
+
     protected List<SpotCommand.RegisterSpotRequest> spotRegisterRequestListToRegisterSpotRequestList(List<SpotRegisterRequest> list) {
         if ( list == null ) {
             return null;
@@ -231,6 +282,19 @@ public class CourseMapperImpl implements CourseMapper {
         List<MyCoursesResponse.CourseInfo> list1 = new ArrayList<MyCoursesResponse.CourseInfo>( list.size() );
         for ( CourseInfo.CourseListInfo courseListInfo : list ) {
             list1.add( of( courseListInfo ) );
+        }
+
+        return list1;
+    }
+
+    protected List<CourseDto> courseSearchInfoListToCourseDtoList(List<CourseInfo.CourseSearchInfo> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<CourseDto> list1 = new ArrayList<CourseDto>( list.size() );
+        for ( CourseInfo.CourseSearchInfo courseSearchInfo : list ) {
+            list1.add( toCourseDto( courseSearchInfo ) );
         }
 
         return list1;

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/SpotMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/SpotMapperImpl.java
@@ -18,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-07T21:27:34+0900",
+    date = "2024-03-11T15:27:23+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
@@ -129,6 +129,7 @@ public class SpotMapperImpl implements SpotMapper {
         MySpotsResponseDto.SpotInfo.SpotInfoBuilder spotInfo1 = MySpotsResponseDto.SpotInfo.builder();
 
         spotInfo1.spotId( spotInfo.getSpotId() );
+        spotInfo1.placeId( spotInfo.getPlaceId() );
         spotInfo1.title( spotInfo.getTitle() );
         spotInfo1.rate( spotInfo.getRate() );
         spotInfo1.imageUrl( spotInfo.getImageUrl() );

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/TravelMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/TravelMapperImpl.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class TravelMapperImpl implements TravelMapper {

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/course/CourseInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/course/CourseInfo.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import kr.co.yigil.travel.domain.Course;
 import kr.co.yigil.travel.domain.Spot;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -76,14 +77,14 @@ public class CourseInfo {
         private final String mapStaticImageUrl;
         private final Boolean isPrivate;
 
-        public CourseListInfo(Course course) {
-            this.courseId = course.getId();
+        public CourseListInfo(CourseListDto course) {
+            this.courseId = course.getCourseId();
             this.title = course.getTitle();
             this.rate = course.getRate();
-            this.spotCount = course.getSpots().size();
-            this.createdDate = course.getCreatedAt();
-            this.isPrivate = course.isPrivate();
-            this.mapStaticImageUrl = course.getMapStaticImageFileUrl();
+            this.spotCount = course.getSpotCount();
+            this.createdDate = course.getCreatedDate();
+            this.isPrivate = course.getIsPrivate();
+            this.mapStaticImageUrl = course.getMapStaticImageUrl();
         }
     }
 

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/course/CourseReader.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/course/CourseReader.java
@@ -2,6 +2,7 @@ package kr.co.yigil.travel.domain.course;
 
 import kr.co.yigil.global.Selected;
 import kr.co.yigil.travel.domain.Course;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -9,7 +10,7 @@ import org.springframework.data.domain.Slice;
 public interface CourseReader {
     Course getCourse(Long courseId);
     Slice<Course> getCoursesSliceInPlace(Long placeId, Pageable pageable);
-    Page<Course> getMemberCourseList(Long memberId, Pageable pageable, Selected selectInfo);
+    Page<CourseListDto> getMemberCourseList(Long memberId, Pageable pageable, Selected selectInfo);
     Slice<Course> searchCourseByPlaceName(String keyword, Pageable pageable);
 }
 

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/course/CourseServiceImpl.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/course/CourseServiceImpl.java
@@ -4,7 +4,6 @@ import static kr.co.yigil.global.exception.ExceptionCode.INVALID_AUTHORITY;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.favor.domain.FavorReader;
 import kr.co.yigil.file.FileUploader;
@@ -19,7 +18,9 @@ import kr.co.yigil.travel.domain.course.CourseCommand.RegisterCourseRequest;
 import kr.co.yigil.travel.domain.course.CourseCommand.RegisterCourseRequestWithSpotInfo;
 import kr.co.yigil.travel.domain.course.CourseInfo.CourseSearchInfo;
 import kr.co.yigil.travel.domain.course.CourseInfo.Main;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -95,7 +96,7 @@ public class CourseServiceImpl implements CourseService {
     @Transactional(readOnly = true)
     public CourseInfo.MyCoursesResponse retrieveCourseList(final Long memberId, final Pageable pageable,
         Selected visibility) {
-        var pageCourse = courseReader.getMemberCourseList(memberId, pageable, visibility);
+        Page<CourseListDto> pageCourse = courseReader.getMemberCourseList(memberId, pageable, visibility);
         List<CourseInfo.CourseListInfo> courseInfoList = pageCourse.getContent().stream()
             .map(CourseInfo.CourseListInfo::new)
             .toList();

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotInfo.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import kr.co.yigil.travel.domain.Spot;
+import kr.co.yigil.travel.domain.dto.SpotListDto;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -71,22 +72,23 @@ public class SpotInfo {
     public static class SpotListInfo {
 
         private final Long spotId;
+        private final Long placeId;
         private final String title;
         private final double rate;
         private final String imageUrl;
         private final LocalDateTime createdDate;
         private final Boolean isPrivate;
 
-        public SpotListInfo(Spot spot) {
-            this.spotId = spot.getId();
-            this.title = spot.getPlace().getName();
+        public SpotListInfo(SpotListDto spot) {
+            this.spotId = spot.getSpotId();
+            this.placeId = spot.getPlaceId();
+            this.title = spot.getTitle();
             this.rate = spot.getRate();
-            this.imageUrl = spot.getAttachFiles().getUrls().getFirst();
-            this.createdDate = spot.getCreatedAt();
-            this.isPrivate = spot.isPrivate();
+            this.imageUrl = spot.getImageUrl();
+            this.createdDate = spot.getCreatedDate();
+            this.isPrivate = spot.getIsPrivate();
         }
     }
-
 
 
     @Getter

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotReader.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotReader.java
@@ -3,6 +3,7 @@ package kr.co.yigil.travel.domain.spot;
 import java.util.List;
 import java.util.Optional;
 
+import kr.co.yigil.travel.domain.dto.SpotListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,7 +24,7 @@ public interface SpotReader {
 
     Page<Spot> getSpotSliceByMemberId(Long memberId, Pageable pageable);
 
-    Page<Spot> getMemberSpotList(Long memberId, Selected selected, Pageable pageable);
+    Page<SpotListDto> getMemberSpotList(Long memberId, Selected selected, Pageable pageable);
 
     boolean isExistSpot(Long placeId, Long memberId);
 }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/infrastructure/course/CourseReaderImpl.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/infrastructure/course/CourseReaderImpl.java
@@ -5,6 +5,7 @@ import kr.co.yigil.global.exception.BadRequestException;
 import kr.co.yigil.global.exception.ExceptionCode;
 import kr.co.yigil.travel.domain.Course;
 import kr.co.yigil.travel.domain.course.CourseReader;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
 import kr.co.yigil.travel.infrastructure.CourseQueryDslRepository;
 import kr.co.yigil.travel.infrastructure.CourseRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class CourseReaderImpl implements CourseReader {
     }
 
     @Override
-    public Page<Course> getMemberCourseList(final Long memberId, final Pageable pageable,
+    public Page<CourseListDto> getMemberCourseList(final Long memberId, final Pageable pageable,
         final Selected visibility) {
         return courseQueryDslRepository.findAllByMemberIdAndIsPrivate(memberId, visibility, pageable);
     }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/infrastructure/spot/SpotReaderImpl.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/infrastructure/spot/SpotReaderImpl.java
@@ -1,23 +1,22 @@
 package kr.co.yigil.travel.infrastructure.spot;
 
-import static kr.co.yigil.global.exception.ExceptionCode.*;
+import static kr.co.yigil.global.exception.ExceptionCode.NOT_FOUND_SPOT_ID;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Component;
-
 import kr.co.yigil.global.Selected;
 import kr.co.yigil.global.exception.BadRequestException;
 import kr.co.yigil.travel.domain.Spot;
+import kr.co.yigil.travel.domain.dto.SpotListDto;
 import kr.co.yigil.travel.domain.spot.SpotReader;
 import kr.co.yigil.travel.infrastructure.SpotQueryDslRepository;
 import kr.co.yigil.travel.infrastructure.SpotRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -61,7 +60,7 @@ public class SpotReaderImpl implements SpotReader {
     }
 
     @Override
-    public Page<Spot> getMemberSpotList(Long memberId, Selected visibility, Pageable pageable
+    public Page<SpotListDto> getMemberSpotList(Long memberId, Selected visibility, Pageable pageable
     ) {
         return spotQueryDslRepository.findAllByMemberIdAndIsPrivate(memberId, visibility, pageable);
     }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/response/MySpotsResponseDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/response/MySpotsResponseDto.java
@@ -19,6 +19,7 @@ public class MySpotsResponseDto {
     public static class SpotInfo {
 
         private final Long spotId;
+        private final Long placeId;
         private final String title;
         private final double rate;
         private final String imageUrl;

--- a/backend/yigil-api/src/main/resources/static/docs/course-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/course-api.html
@@ -1666,7 +1666,7 @@ Content-Length: 324
     "spot_count" : 3,
     "rate" : 4.5,
     "liked" : false,
-    "create_date" : "2024-03-10T02:55:12.445159"
+    "create_date" : "2024-03-11T15:46:51.605417"
   } ],
   "has_next" : false
 }</code></pre>

--- a/backend/yigil-api/src/main/resources/static/docs/index.html
+++ b/backend/yigil-api/src/main/resources/static/docs/index.html
@@ -1444,6 +1444,11 @@ Host: spring.restdocs.test</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">장소 ID</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].place_id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소 ID</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].title</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">장소 제목</p></td>
@@ -1481,11 +1486,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 210
+Content-Length: 233
 
 {
   "content" : [ {
     "spot_id" : 1,
+    "place_id" : null,
     "title" : "test course",
     "rate" : 4.5,
     "image_url" : "images/map.jpg",
@@ -2728,7 +2734,7 @@ Content-Length: 324
     "spot_count" : 3,
     "rate" : 4.5,
     "liked" : false,
-    "create_date" : "2024-03-10T02:55:12.445159"
+    "create_date" : "2024-03-11T15:46:51.605417"
   } ],
   "has_next" : false
 }</code></pre>
@@ -3029,6 +3035,11 @@ Host: spring.restdocs.test</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">찾은 파일의 이미지 Url</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>registered_place</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버가 해당 장소의 스팟을 등록했는지 여부</p></td>
+</tr>
 </tbody>
 </table>
 <div class="sect4">
@@ -3037,11 +3048,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 70
+Content-Length: 100
 
 {
   "exists" : true,
-  "map_static_image_url" : "http://yigil.co.kr"
+  "map_static_image_url" : "http://yigil.co.kr",
+  "registered_place" : false
 }</code></pre>
 </div>
 </div>
@@ -6676,7 +6688,7 @@ Content-Length: 524
 
 id:1
 event:test event
-data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-10T02:55:10.360581","modified_at":"2024-03-10T02:55:10.360586","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-10T02:55:10.360588","modified_at":"2024-03-10T02:55:10.360589","read":false}</code></pre>
+data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-11T15:46:49.515537","modified_at":"2024-03-11T15:46:49.515539","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-11T15:46:49.515541","modified_at":"2024-03-11T15:46:49.515541","read":false}</code></pre>
 </div>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/notification-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/notification-api.html
@@ -580,7 +580,7 @@ Content-Length: 524
 
 id:1
 event:test event
-data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-10T02:55:10.360581","modified_at":"2024-03-10T02:55:10.360586","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-10T02:55:10.360588","modified_at":"2024-03-10T02:55:10.360589","read":false}</code></pre>
+data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-11T15:46:49.515537","modified_at":"2024-03-11T15:46:49.515539","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-11T15:46:49.515541","modified_at":"2024-03-11T15:46:49.515541","read":false}</code></pre>
 </div>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/place-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/place-api.html
@@ -516,6 +516,11 @@ Host: spring.restdocs.test</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">찾은 파일의 이미지 Url</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>registered_place</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버가 해당 장소의 스팟을 등록했는지 여부</p></td>
+</tr>
 </tbody>
 </table>
 <div class="sect4">
@@ -524,11 +529,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 70
+Content-Length: 100
 
 {
   "exists" : true,
-  "map_static_image_url" : "http://yigil.co.kr"
+  "map_static_image_url" : "http://yigil.co.kr",
+  "registered_place" : false
 }</code></pre>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/spot-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/spot-api.html
@@ -1323,6 +1323,11 @@ Host: spring.restdocs.test</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">장소 ID</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].place_id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">장소 ID</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].title</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">장소 제목</p></td>
@@ -1360,11 +1365,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 210
+Content-Length: 233
 
 {
   "content" : [ {
     "spot_id" : 1,
+    "place_id" : null,
     "title" : "test course",
     "rate" : 4.5,
     "image_url" : "images/map.jpg",

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/application/CourseFacadeTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/application/CourseFacadeTest.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.file.AttachFile;
-import kr.co.yigil.file.FileType;
 import kr.co.yigil.file.FileUploader;
 import kr.co.yigil.global.Selected;
 import kr.co.yigil.member.Ages;
@@ -31,6 +30,7 @@ import kr.co.yigil.travel.domain.course.CourseCommand.RegisterCourseRequest;
 import kr.co.yigil.travel.domain.course.CourseCommand.RegisterCourseRequestWithSpotInfo;
 import kr.co.yigil.travel.domain.course.CourseInfo;
 import kr.co.yigil.travel.domain.course.CourseService;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -175,14 +175,12 @@ public class CourseFacadeTest {
         Long courseId = 1L;
         String title = "Test Course Title";
         double rate = 5.0;
-        LineString path = null;
         boolean isPrivate = false;
-        List<Spot> spots = Collections.emptyList();
-        int representativeSpotOrder = 0;
-        AttachFile mapStaticImageFile = new AttachFile(FileType.IMAGE, "test.jpg", "test.jpg", 10L);
+        int numberOfSpots = 3;
+        String imageUrl = "test.jpg";
 
-        Course mockCourse = new Course(courseId, member, title, null, rate, path, isPrivate,
-                spots, representativeSpotOrder, mapStaticImageFile);
+        CourseListDto mockCourse = new CourseListDto(courseId, title, rate, imageUrl,
+                numberOfSpots, null, isPrivate);
 
         CourseInfo.CourseListInfo courseInfo = new CourseInfo.CourseListInfo(mockCourse);
         List<CourseInfo.CourseListInfo> courseList = Collections.singletonList(courseInfo);

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/application/SpotFacadeTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/application/SpotFacadeTest.java
@@ -10,20 +10,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import kr.co.yigil.auth.domain.Accessor;
-import kr.co.yigil.file.AttachFile;
-import kr.co.yigil.file.AttachFiles;
-import kr.co.yigil.file.FileType;
 import kr.co.yigil.file.FileUploader;
 import kr.co.yigil.global.Selected;
-import kr.co.yigil.member.Ages;
-import kr.co.yigil.member.Gender;
-import kr.co.yigil.member.Member;
-import kr.co.yigil.member.SocialLoginType;
-import kr.co.yigil.place.domain.Place;
-import kr.co.yigil.travel.domain.Spot;
+import kr.co.yigil.travel.domain.dto.SpotListDto;
 import kr.co.yigil.travel.domain.spot.SpotCommand.ModifySpotRequest;
 import kr.co.yigil.travel.domain.spot.SpotCommand.RegisterSpotRequest;
 import kr.co.yigil.travel.domain.spot.SpotInfo;
@@ -36,10 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 @ExtendWith(MockitoExtension.class)
 public class SpotFacadeTest {
@@ -142,22 +133,15 @@ public class SpotFacadeTest {
         int totalPages = 1;
         PageRequest pageable = PageRequest.of(0, 5);
 
-        String email = "test@test.com";
-        String socialLoginId = "12345";
-        String nickname = "tester";
-        String profileImageUrl = "test.jpg";
-        Member member = new Member(memberId, email, socialLoginId, nickname, profileImageUrl,
-            SocialLoginType.KAKAO, Ages.NONE, Gender.NONE);
-
         Long spotId = 1L;
         String title = "Test Spot Title";
         double rate = 5.0;
-        AttachFile imageFile = new AttachFile(FileType.IMAGE, "test.jpg", "test.jpg", 10L);
-        AttachFiles imageFiles = new AttachFiles(Collections.singletonList(imageFile));
+        Long placeId = 1L;
+        String imageUrl = "test.jpg";
 
-        Place mockPlace = mock(Place.class);
-        when(mockPlace.getName()).thenReturn("장소명");
-        Spot spot = new Spot(spotId, member, null, false, title, null, imageFiles, mockPlace, rate);
+
+        SpotListDto spot = new SpotListDto(spotId, placeId, title, rate, imageUrl,
+            LocalDateTime.now(), false);
 
         SpotInfo.SpotListInfo spotInfo = new SpotInfo.SpotListInfo(spot);
         List<SpotInfo.SpotListInfo> spotList = Collections.singletonList(spotInfo);

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/domain/course/CourseServiceImplTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/domain/course/CourseServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import kr.co.yigil.auth.domain.Accessor;
@@ -24,10 +25,10 @@ import kr.co.yigil.travel.domain.Spot;
 import kr.co.yigil.travel.domain.course.CourseCommand.ModifyCourseRequest;
 import kr.co.yigil.travel.domain.course.CourseCommand.RegisterCourseRequest;
 import kr.co.yigil.travel.domain.course.CourseInfo.Main;
+import kr.co.yigil.travel.domain.dto.CourseListDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.locationtech.jts.geom.LineString;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -177,11 +178,11 @@ public class CourseServiceImplTest {
         PageRequest pageable = PageRequest.of(0, 10);
 
         // 필요 course 필드: id, title, rate, spotList, mapstaticImageUrl
+        String mapStaticImageUrl = "test.jpg";
 
-        Course mockCourse = new Course(
-            courseId, mock(Member.class), "title", null, 4.5, mock(LineString.class), false,
-            List.of(mock(Spot.class)), 1, mock(AttachFile.class));
-        PageImpl<Course> mockCourseList = new PageImpl<>(List.of(mockCourse));
+        CourseListDto mockCourse = new CourseListDto(courseId, "test", 5.0,
+            mapStaticImageUrl, 1, LocalDateTime.now(), false);
+        PageImpl<CourseListDto> mockCourseList = new PageImpl<>(List.of(mockCourse));
 
 
         when(courseReader.getMemberCourseList(anyLong(), any(), any())).thenReturn(mockCourseList);

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/domain/spot/SpotServiceImplTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/domain/spot/SpotServiceImplTest.java
@@ -32,6 +32,7 @@ import kr.co.yigil.place.domain.PlaceCacheStore;
 import kr.co.yigil.place.domain.PlaceReader;
 import kr.co.yigil.place.domain.PlaceStore;
 import kr.co.yigil.travel.domain.Spot;
+import kr.co.yigil.travel.domain.dto.SpotListDto;
 import kr.co.yigil.travel.domain.spot.SpotCommand.ModifySpotRequest;
 import kr.co.yigil.travel.domain.spot.SpotCommand.RegisterPlaceRequest;
 import kr.co.yigil.travel.domain.spot.SpotCommand.RegisterSpotRequest;
@@ -40,7 +41,6 @@ import kr.co.yigil.travel.domain.spot.SpotInfo.MySpot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.locationtech.jts.geom.Point;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -287,13 +287,11 @@ public class SpotServiceImplTest {
         PageRequest pageable = PageRequest.of(0, 10);
         AttachFile mockAttachFile = new AttachFile(mock(FileType.class), "fileUrl",
             "originalFileName", 100L);
-        AttachFiles mockAttachFiles = new AttachFiles(List.of(mockAttachFile));
-        Member mockMember = mock(Member.class);
-        Place mockPlace = mock(Place.class);
-        Spot mockSpot = new Spot(spotId, mockMember, mock(Point.class), false, "title",
-            "description", mockAttachFiles, mockPlace, 3.5);
-        PageImpl<Spot> mockSpotList = new PageImpl<>(List.of(mockSpot));
-        when(mockPlace.getName()).thenReturn("장소장소");
+
+        SpotListDto mockSpotListDto = new SpotListDto(spotId, 1L, "title", 3.5, "fileUrl",
+            LocalDateTime.now(), false);
+        PageImpl<SpotListDto> mockSpotList = new PageImpl<>(List.of(mockSpotListDto));
+
         when(spotReader.getMemberSpotList(anyLong(), any(Selected.class), any())).thenReturn(mockSpotList);
 
         var result = spotService.retrieveSpotList(memberId, Selected.PRIVATE, pageable);
@@ -301,6 +299,5 @@ public class SpotServiceImplTest {
         assertThat(result).isNotNull().isInstanceOf(SpotInfo.MySpotsResponse.class);
         assertThat(result.getContent().getFirst()).isInstanceOf(SpotInfo.SpotListInfo.class);
     }
-
 
 }

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
@@ -364,6 +364,7 @@ class SpotApiControllerTest {
                 ),
                 responseFields(
                     fieldWithPath("content[].spot_id").description("장소 ID"),
+                    fieldWithPath("content[].place_id").description("장소 ID"),
                     fieldWithPath("content[].title").description("장소 제목"),
                     fieldWithPath("content[].rate").description("장소 평점"),
                     fieldWithPath("content[].image_url").description("장소 이미지 URL"),


### PR DESCRIPTION
## Motivation 🧐
querydsl를 사용하는 메서드에서 스팟이나 코스를 리턴할 때 필요한 정보만 보내주도록 변경하였습니다.

<br>

## Key Changes 🔑
- repository에서 사용하는 dto 생성
- dto에 맞게 쿼리 dsl 수정
<br>

## To Reviewers 🙏
- 테스트 작성
- api 테스트
- 성능 측정
<img width="1109" alt="스크린샷 2024-03-11 오후 6 47 12" src="https://github.com/Kernel360/f1-Yigil/assets/124959156/247dae42-1b84-42d8-82e5-0deff05066a7">

<img width="1086" alt="스크린샷 2024-03-11 오후 6 46 19" src="https://github.com/Kernel360/f1-Yigil/assets/124959156/9246885e-23a1-4596-9b6d-3d398222242c">

데이터가 많지 않은 로컬에서 테스트 해봐서 정확하진 않지만 유의미한 성능 개선이 있을 것으로 생각됩니다.

