### PR TITLE
491 update 메서드 post put 으로 변경

### DIFF
--- a/backend/yigil-api/src/main/generated/kr/co/yigil/bookmark/interfaces/dto/mapper/BookmarkMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/bookmark/interfaces/dto/mapper/BookmarkMapperImpl.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class BookmarkMapperImpl implements BookmarkMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/comment/interfaces/dto/mapper/CommentMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/comment/interfaces/dto/mapper/CommentMapperImpl.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class CommentMapperImpl implements CommentMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/favor/interfaces/dto/mapper/FavorMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/favor/interfaces/dto/mapper/FavorMapperImpl.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class FavorMapperImpl implements FavorMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/follow/interfaces/dto/FollowDtoMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/follow/interfaces/dto/FollowDtoMapperImpl.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-05T14:42:07+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class FollowDtoMapperImpl implements FollowDtoMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/login/interfaces/dto/mapper/LoginMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/login/interfaces/dto/mapper/LoginMapperImpl.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class LoginMapperImpl implements LoginMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/member/interfaces/dto/mapper/MemberDtoMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/member/interfaces/dto/mapper/MemberDtoMapperImpl.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-08T23:30:40+0900",
+    date = "2024-03-11T15:27:23+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/notification/interfaces/dto/mapper/NotificationMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/notification/interfaces/dto/mapper/NotificationMapperImpl.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class NotificationMapperImpl implements NotificationMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/place/interfaces/dto/mapper/PlaceMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/place/interfaces/dto/mapper/PlaceMapperImpl.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-09T21:52:28+0900",
+    date = "2024-03-11T15:38:21+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/region/interfaces/dto/mapper/RegionMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/region/interfaces/dto/mapper/RegionMapperImpl.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class RegionMapperImpl implements RegionMapper {

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/CourseMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/CourseMapperImpl.java
@@ -1,5 +1,6 @@
 package kr.co.yigil.travel.interfaces.dto.mapper;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,20 +10,22 @@ import kr.co.yigil.travel.domain.course.CourseCommand;
 import kr.co.yigil.travel.domain.course.CourseInfo;
 import kr.co.yigil.travel.domain.spot.SpotCommand;
 import kr.co.yigil.travel.interfaces.dto.CourseDetailInfoDto;
+import kr.co.yigil.travel.interfaces.dto.CourseDto;
 import kr.co.yigil.travel.interfaces.dto.CourseInfoDto;
 import kr.co.yigil.travel.interfaces.dto.request.CourseRegisterRequest;
 import kr.co.yigil.travel.interfaces.dto.request.CourseRegisterWithoutSeriesRequest;
 import kr.co.yigil.travel.interfaces.dto.request.CourseUpdateRequest;
 import kr.co.yigil.travel.interfaces.dto.request.SpotRegisterRequest;
 import kr.co.yigil.travel.interfaces.dto.request.SpotUpdateRequest;
+import kr.co.yigil.travel.interfaces.dto.response.CourseSearchResponse;
 import kr.co.yigil.travel.interfaces.dto.response.MyCoursesResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class CourseMapperImpl implements CourseMapper {
@@ -184,6 +187,54 @@ public class CourseMapperImpl implements CourseMapper {
         return courseInfo.build();
     }
 
+    @Override
+    public CourseSearchResponse toCourseSearchResponse(CourseInfo.Slice slice) {
+        if ( slice == null ) {
+            return null;
+        }
+
+        List<CourseDto> courses = null;
+        boolean hasNext = false;
+
+        courses = courseSearchInfoListToCourseDtoList( slice.getCourses() );
+        hasNext = slice.isHasNext();
+
+        CourseSearchResponse courseSearchResponse = new CourseSearchResponse( courses, hasNext );
+
+        return courseSearchResponse;
+    }
+
+    @Override
+    public CourseDto toCourseDto(CourseInfo.CourseSearchInfo courseSearchInfo) {
+        if ( courseSearchInfo == null ) {
+            return null;
+        }
+
+        LocalDateTime createDate = null;
+        Long id = null;
+        String title = null;
+        String mapStaticImageUrl = null;
+        String ownerProfileImageUrl = null;
+        String ownerNickname = null;
+        int spotCount = 0;
+        double rate = 0.0d;
+        boolean liked = false;
+
+        createDate = courseSearchInfo.getCreateDate();
+        id = courseSearchInfo.getId();
+        title = courseSearchInfo.getTitle();
+        mapStaticImageUrl = courseSearchInfo.getMapStaticImageUrl();
+        ownerProfileImageUrl = courseSearchInfo.getOwnerProfileImageUrl();
+        ownerNickname = courseSearchInfo.getOwnerNickname();
+        spotCount = courseSearchInfo.getSpotCount();
+        rate = courseSearchInfo.getRate();
+        liked = courseSearchInfo.isLiked();
+
+        CourseDto courseDto = new CourseDto( id, title, mapStaticImageUrl, ownerProfileImageUrl, ownerNickname, spotCount, rate, liked, createDate );
+
+        return courseDto;
+    }
+
     protected List<SpotCommand.RegisterSpotRequest> spotRegisterRequestListToRegisterSpotRequestList(List<SpotRegisterRequest> list) {
         if ( list == null ) {
             return null;
@@ -231,6 +282,19 @@ public class CourseMapperImpl implements CourseMapper {
         List<MyCoursesResponse.CourseInfo> list1 = new ArrayList<MyCoursesResponse.CourseInfo>( list.size() );
         for ( CourseInfo.CourseListInfo courseListInfo : list ) {
             list1.add( of( courseListInfo ) );
+        }
+
+        return list1;
+    }
+
+    protected List<CourseDto> courseSearchInfoListToCourseDtoList(List<CourseInfo.CourseSearchInfo> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<CourseDto> list1 = new ArrayList<CourseDto>( list.size() );
+        for ( CourseInfo.CourseSearchInfo courseSearchInfo : list ) {
+            list1.add( toCourseDto( courseSearchInfo ) );
         }
 
         return list1;

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/SpotMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/SpotMapperImpl.java
@@ -18,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-07T21:27:34+0900",
+    date = "2024-03-11T15:27:23+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
@@ -129,6 +129,7 @@ public class SpotMapperImpl implements SpotMapper {
         MySpotsResponseDto.SpotInfo.SpotInfoBuilder spotInfo1 = MySpotsResponseDto.SpotInfo.builder();
 
         spotInfo1.spotId( spotInfo.getSpotId() );
+        spotInfo1.placeId( spotInfo.getPlaceId() );
         spotInfo1.title( spotInfo.getTitle() );
         spotInfo1.rate( spotInfo.getRate() );
         spotInfo1.imageUrl( spotInfo.getImageUrl() );

--- a/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/TravelMapperImpl.java
+++ b/backend/yigil-api/src/main/generated/kr/co/yigil/travel/interfaces/dto/mapper/TravelMapperImpl.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-04T18:48:06+0900",
-    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.1 (Oracle Corporation)"
+    date = "2024-03-11T15:27:23+0900",
+    comments = "version: 1.5.5.Final, compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 @Component
 public class TravelMapperImpl implements TravelMapper {

--- a/backend/yigil-api/src/main/java/kr/co/yigil/comment/interfaces/controller/CommentApiController.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/comment/interfaces/controller/CommentApiController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -75,7 +76,7 @@ public class CommentApiController {
         return ResponseEntity.ok().body(response);
     }
 
-    @PostMapping("/{comment_id}")
+    @PutMapping("/{comment_id}")
     @MemberOnly
     public ResponseEntity<CommentDto.CommentUpdateResponse> updateComment(
         @PathVariable("comment_id") Long commentId,

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/interfaces/controller/MemberApiController.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/interfaces/controller/MemberApiController.java
@@ -1,15 +1,5 @@
 package kr.co.yigil.member.interfaces.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import jakarta.servlet.http.HttpServletRequest;
 import kr.co.yigil.auth.Auth;
 import kr.co.yigil.auth.MemberOnly;
@@ -19,6 +9,15 @@ import kr.co.yigil.member.domain.MemberInfo;
 import kr.co.yigil.member.interfaces.dto.MemberDto;
 import kr.co.yigil.member.interfaces.dto.mapper.MemberDtoMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotInfo.java
@@ -71,6 +71,7 @@ public class SpotInfo {
     public static class SpotListInfo {
 
         private final Long spotId;
+        private final Long placeId;
         private final String title;
         private final double rate;
         private final String imageUrl;
@@ -79,6 +80,7 @@ public class SpotInfo {
 
         public SpotListInfo(Spot spot) {
             this.spotId = spot.getId();
+            this.placeId = spot.getPlace().getId();
             this.title = spot.getPlace().getName();
             this.rate = spot.getRate();
             this.imageUrl = spot.getAttachFiles().getUrls().getFirst();

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/controller/TravelApiController.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/controller/TravelApiController.java
@@ -11,7 +11,7 @@ import kr.co.yigil.travel.interfaces.dto.response.ChangeStatusTravelResponse;
 import kr.co.yigil.travel.interfaces.dto.response.TravelsVisibilityChangeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +23,7 @@ public class TravelApiController {
     private final TravelFacade travelFacade;
     private final TravelMapper travelMapper;
 
-    @PostMapping("/change-on-public")
+    @PutMapping("/change-on-public")
     @MemberOnly
     public ResponseEntity<ChangeStatusTravelResponse> changeOnPublicTravel(
             @RequestBody ChangeStatusTravelRequest request,
@@ -33,7 +33,7 @@ public class TravelApiController {
         return ResponseEntity.ok().body(new ChangeStatusTravelResponse("리뷰 공개 상태 변경 완료"));
     }
 
-    @PostMapping("/change-on-private")
+    @PutMapping("/change-on-private")
     @MemberOnly
     public ResponseEntity<ChangeStatusTravelResponse> changeOnPrivateTravel(
             @RequestBody ChangeStatusTravelRequest request,
@@ -43,7 +43,7 @@ public class TravelApiController {
         return ResponseEntity.ok().body(new ChangeStatusTravelResponse("리뷰 공개 상태 변경 완료"));
     }
 
-    @PostMapping("/change-visibility")
+    @PutMapping("/change-visibility")
     @MemberOnly
     public ResponseEntity<TravelsVisibilityChangeResponse> setTravelsVisibility(
         @Auth final Accessor accessor,

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/response/MySpotsResponseDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/response/MySpotsResponseDto.java
@@ -19,6 +19,7 @@ public class MySpotsResponseDto {
     public static class SpotInfo {
 
         private final Long spotId;
+        private final Long placeId;
         private final String title;
         private final double rate;
         private final String imageUrl;

--- a/backend/yigil-api/src/main/resources/static/docs/comment-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/comment-api.html
@@ -948,7 +948,7 @@ Content-Length: 40
 <h5 id="_http_request_예시_5">HTTP Request 예시</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/comments/1 HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/comments/1 HTTP/1.1
 Content-Type: application/json
 Content-Length: 27
 Host: spring.restdocs.test

--- a/backend/yigil-api/src/main/resources/static/docs/course-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/course-api.html
@@ -1666,7 +1666,7 @@ Content-Length: 324
     "spot_count" : 3,
     "rate" : 4.5,
     "liked" : false,
-    "create_date" : "2024-03-10T02:55:12.445159"
+    "create_date" : "2024-03-12T11:03:08.598549"
   } ],
   "has_next" : false
 }</code></pre>

--- a/backend/yigil-api/src/main/resources/static/docs/index.html
+++ b/backend/yigil-api/src/main/resources/static/docs/index.html
@@ -1441,6 +1441,11 @@ Host: spring.restdocs.test</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].spot_id</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글(리뷰) ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].place_id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">장소 ID</p></td>
 </tr>
 <tr>
@@ -1481,11 +1486,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 210
+Content-Length: 233
 
 {
   "content" : [ {
     "spot_id" : 1,
+    "place_id" : null,
     "title" : "test course",
     "rate" : 4.5,
     "image_url" : "images/map.jpg",
@@ -2728,7 +2734,7 @@ Content-Length: 324
     "spot_count" : 3,
     "rate" : 4.5,
     "liked" : false,
-    "create_date" : "2024-03-10T02:55:12.445159"
+    "create_date" : "2024-03-12T11:03:08.598549"
   } ],
   "has_next" : false
 }</code></pre>
@@ -2760,7 +2766,7 @@ Content-Length: 324
 <h5 id="_http_request_예시_16"><a class="link" href="#_http_request_예시_16">HTTP Request 예시</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/travels/change-on-public HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/travels/change-on-public HTTP/1.1
 Content-Type: application/json
 Content-Length: 21
 Host: spring.restdocs.test
@@ -2829,7 +2835,7 @@ Content-Length: 54
 <h5 id="_http_request_예시_17"><a class="link" href="#_http_request_예시_17">HTTP Request 예시</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/travels/change-on-private HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/travels/change-on-private HTTP/1.1
 Content-Type: application/json
 Content-Length: 21
 Host: spring.restdocs.test
@@ -2899,7 +2905,7 @@ Content-Length: 54
 <h5 id="_http_request_예시_18"><a class="link" href="#_http_request_예시_18">HTTP Request 예시</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/travels/change-visibility HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/travels/change-visibility HTTP/1.1
 Content-Type: application/json
 Content-Length: 50
 Host: spring.restdocs.test
@@ -3029,6 +3035,11 @@ Host: spring.restdocs.test</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">찾은 파일의 이미지 Url</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>registered_place</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버가 해당 장소의 스팟을 등록했는지 여부</p></td>
+</tr>
 </tbody>
 </table>
 <div class="sect4">
@@ -3037,11 +3048,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 70
+Content-Length: 100
 
 {
   "exists" : true,
-  "map_static_image_url" : "http://yigil.co.kr"
+  "map_static_image_url" : "http://yigil.co.kr",
+  "registered_place" : false
 }</code></pre>
 </div>
 </div>
@@ -5295,7 +5307,7 @@ Content-Length: 40
 <h5 id="_http_request_예시_41"><a class="link" href="#_http_request_예시_41">HTTP Request 예시</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/comments/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/comments/1 HTTP/1.1
 Content-Type: application/json
 Content-Length: 27
 Host: spring.restdocs.test
@@ -6676,7 +6688,7 @@ Content-Length: 524
 
 id:1
 event:test event
-data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-10T02:55:10.360581","modified_at":"2024-03-10T02:55:10.360586","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-10T02:55:10.360588","modified_at":"2024-03-10T02:55:10.360589","read":false}</code></pre>
+data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-12T11:03:06.448543","modified_at":"2024-03-12T11:03:06.448546","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-12T11:03:06.448548","modified_at":"2024-03-12T11:03:06.448548","read":false}</code></pre>
 </div>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/notification-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/notification-api.html
@@ -580,7 +580,7 @@ Content-Length: 524
 
 id:1
 event:test event
-data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-10T02:55:10.360581","modified_at":"2024-03-10T02:55:10.360586","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-10T02:55:10.360588","modified_at":"2024-03-10T02:55:10.360589","read":false}</code></pre>
+data:{"id":null,"member":{"id":1,"email":"email","social_login_id":"12345678","nickname":"nickname","profile_image_url":"http://cdn.yigil.co.kr/image.jpg","status":"ACTIVE","social_login_type":"KAKAO","gender":"NONE","ages":"NONE","favorite_regions":[],"joined_at":"2024-03-12T11:03:06.448543","modified_at":"2024-03-12T11:03:06.448546","favorite_region_ids":[]},"message":"새로운 알림입니다.","created_at":"2024-03-12T11:03:06.448548","modified_at":"2024-03-12T11:03:06.448548","read":false}</code></pre>
 </div>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/place-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/place-api.html
@@ -516,6 +516,11 @@ Host: spring.restdocs.test</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">찾은 파일의 이미지 Url</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>registered_place</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">멤버가 해당 장소의 스팟을 등록했는지 여부</p></td>
+</tr>
 </tbody>
 </table>
 <div class="sect4">
@@ -524,11 +529,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 70
+Content-Length: 100
 
 {
   "exists" : true,
-  "map_static_image_url" : "http://yigil.co.kr"
+  "map_static_image_url" : "http://yigil.co.kr",
+  "registered_place" : false
 }</code></pre>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/spot-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/spot-api.html
@@ -1320,6 +1320,11 @@ Host: spring.restdocs.test</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].spot_id</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글(리뷰) ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].place_id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">장소 ID</p></td>
 </tr>
 <tr>
@@ -1360,11 +1365,12 @@ Host: spring.restdocs.test</code></pre>
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 210
+Content-Length: 233
 
 {
   "content" : [ {
     "spot_id" : 1,
+    "place_id" : null,
     "title" : "test course",
     "rate" : 4.5,
     "image_url" : "images/map.jpg",

--- a/backend/yigil-api/src/main/resources/static/docs/travel-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/travel-api.html
@@ -461,7 +461,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h5 id="_http_request_예시">HTTP Request 예시</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/travels/change-on-public HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/travels/change-on-public HTTP/1.1
 Content-Type: application/json
 Content-Length: 21
 Host: spring.restdocs.test
@@ -530,7 +530,7 @@ Content-Length: 54
 <h5 id="_http_request_예시_2">HTTP Request 예시</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/travels/change-on-private HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/travels/change-on-private HTTP/1.1
 Content-Type: application/json
 Content-Length: 21
 Host: spring.restdocs.test
@@ -600,7 +600,7 @@ Content-Length: 54
 <h5 id="_http_request_예시_3">HTTP Request 예시</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/travels/change-visibility HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/travels/change-visibility HTTP/1.1
 Content-Type: application/json
 Content-Length: 50
 Host: spring.restdocs.test

--- a/backend/yigil-api/src/test/java/kr/co/yigil/comment/interfaces/controller/CommentApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/comment/interfaces/controller/CommentApiControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -224,7 +225,7 @@ class CommentApiControllerTest {
         when(commentMapper.of(any(CommentDto.CommentUpdateRequest.class))).thenReturn(
             mock(CommentCommand.CommentUpdateRequest.class));
 
-        mockMvc.perform(post("/api/v1/comments/{commentId}", 1L)
+        mockMvc.perform(put("/api/v1/comments/{commentId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
             .andExpect(status().isOk())

--- a/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
@@ -134,10 +134,6 @@ class MemberApiControllerTest {
 
         mockMvc.perform(multipart("/api/v1/members")
                 .file("profileImageFile", multipartFile.getBytes())
-//                .param("nickname", "nickname")
-//                .param("age", "10대")
-//                .param("gender", "남성")
-//                .param("favoriteRegionIds", "1", "2", "3")
                 .content(requestJson)
                 .contentType(MediaType.MULTIPART_FORM_DATA)
             )
@@ -148,6 +144,12 @@ class MemberApiControllerTest {
                 getDocumentResponse(),
                 requestParts(
                     partWithName("profileImageFile").description("프로필 이미지 파일")
+                ),
+                requestFields(
+                    fieldWithPath("nickname").description("닉네임"),
+                    fieldWithPath("age").description("연령대"),
+                    fieldWithPath("gender").description("성별"),
+                    fieldWithPath("favoriteRegionIds").description("좋아하는 지역 ID 리스트")
                 ),
                 responseFields(
                     fieldWithPath("message").description("메시지")
@@ -236,9 +238,8 @@ class MemberApiControllerTest {
     }
 
     @DisplayName("닉네임 중복 체크가 잘 되는지")
-	@Test
-	void whenNicknameDuplicateCheck_thenShouldReturn200AndResponse() throws Exception{
-
+    @Test
+    void whenNicknameDuplicateCheck_thenShouldReturn200AndResponse() throws Exception {
 
         MemberInfo.NicknameCheckInfo checkInfo = new MemberInfo.NicknameCheckInfo(true);
         MemberDto.NicknameCheckResponse response = MemberDto.NicknameCheckResponse.builder()
@@ -265,5 +266,5 @@ class MemberApiControllerTest {
             ));
 
         verify(memberFacade).nicknameDuplicateCheck(anyString());
-	}
+    }
 }

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
@@ -363,7 +363,8 @@ class SpotApiControllerTest {
                         "필터 기능 - all(디폴트값) 전체공개 / private 비공개").optional()
                 ),
                 responseFields(
-                    fieldWithPath("content[].spot_id").description("장소 ID"),
+                    fieldWithPath("content[].spot_id").description("게시글(리뷰) ID"),
+                    fieldWithPath("content[].place_id").description("장소 ID"),
                     fieldWithPath("content[].title").description("장소 제목"),
                     fieldWithPath("content[].rate").description("장소 평점"),
                     fieldWithPath("content[].image_url").description("장소 이미지 URL"),

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/TravelApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/TravelApiControllerTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -58,7 +58,7 @@ public class TravelApiControllerTest {
     @Test
     void changeOnPublicTravel_ReturnsOk() throws Exception {
 
-        mockMvc.perform(post("/api/v1/travels/change-on-public")
+        mockMvc.perform(put("/api/v1/travels/change-on-public")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"travel_id\":1}"))
             .andExpect(status().isOk())
@@ -81,7 +81,7 @@ public class TravelApiControllerTest {
     @Test
     void changeOnPrivateTravel_ReturnsOk() throws Exception {
 
-        mockMvc.perform(post("/api/v1/travels/change-on-private")
+        mockMvc.perform(put("/api/v1/travels/change-on-private")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"travel_id\":2}"))
             .andExpect(status().isOk())
@@ -110,7 +110,7 @@ public class TravelApiControllerTest {
 
         when(travelMapper.of(anyString())).thenReturn(response);
 
-        mockMvc.perform(post("/api/v1/travels/change-visibility")
+        mockMvc.perform(put("/api/v1/travels/change-visibility")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"visibility\": \"public\"}")
                 .content("{\"travel_ids\": [1], \"is_private\": false}")
@@ -120,6 +120,10 @@ public class TravelApiControllerTest {
                 "travels/set-travels-visibility",
                 getDocumentRequest(),
                 getDocumentResponse(),
+                requestFields(
+                    fieldWithPath("travel_ids").description("travel의 id"),
+                    fieldWithPath("is_private").description("공개 여부")
+                ),
                 responseFields(
                     fieldWithPath("message").description("메시지")
                 )


### PR DESCRIPTION
## Motivation 🧐
restful api를 지키고자 하는 노력의 일환으로 수정 하는 메서드를 post에서 put으로 변경
<br>

## Key Changes 🔑
- 업데이트 메서드 변경
<br>

## To Reviewers 🙏
- multipart 리퀘스트는 기본적으로 post로 기본 설정되어 있는 것 같습니다. 때문에 put으로 변경하지 못했습니다.
- 동작 테스트 확인했습니다
- 단위 테스트 수정하고 확인했습니다.
- 문서화 업데이트 했습니다