### PR TITLE
홈페이지 장소 목록에서 더보기만큼의 장소 개수가 로딩되는 현상 수정

### DIFF
--- a/frontend/src/app/(with-header)/(home)/action.ts
+++ b/frontend/src/app/(with-header)/(home)/action.ts
@@ -57,7 +57,7 @@ async function fetchRegionPlaces(id: number) {
   return await response.json();
 }
 
-export async function getPopularPlaces(more: 'more' | undefined = 'more') {
+export async function getPopularPlaces(more: 'more' | undefined) {
   const json = await fetchPopularPlaces(more);
 
   const result = placeResponseSchema.safeParse(json);

--- a/frontend/src/app/(with-header)/(home)/action.ts
+++ b/frontend/src/app/(with-header)/(home)/action.ts
@@ -14,7 +14,7 @@ const regionResponseSchema = z.object({
   regions: z.array(regionSchema),
 });
 
-async function fetchPopularPlaces(more: 'more' | undefined) {
+async function fetchPopularPlaces(more?: 'more') {
   const BASE_URL = await getBaseUrl();
   const session = cookies().get('SESSION')?.value;
 
@@ -57,7 +57,7 @@ async function fetchRegionPlaces(id: number) {
   return await response.json();
 }
 
-export async function getPopularPlaces(more: 'more' | undefined) {
+export async function getPopularPlaces(more?: 'more') {
   const json = await fetchPopularPlaces(more);
 
   const result = placeResponseSchema.safeParse(json);

--- a/frontend/src/app/(with-header)/(home)/page.tsx
+++ b/frontend/src/app/(with-header)/(home)/page.tsx
@@ -28,7 +28,7 @@ export default async function HomePage({
 }: {
   searchParams: { name: string };
 }) {
-  const popularPlacesResult = await getPopularPlaces();
+  const popularPlacesResult = await getPopularPlaces(undefined);
 
   if (!popularPlacesResult.success) {
     console.log(popularPlacesResult.error.errors);

--- a/frontend/src/app/(with-header)/(home)/page.tsx
+++ b/frontend/src/app/(with-header)/(home)/page.tsx
@@ -28,7 +28,7 @@ export default async function HomePage({
 }: {
   searchParams: { name: string };
 }) {
-  const popularPlacesResult = await getPopularPlaces(undefined);
+  const popularPlacesResult = await getPopularPlaces();
 
   if (!popularPlacesResult.success) {
     console.log(popularPlacesResult.error.errors);


### PR DESCRIPTION
## Motivation 🧐
홈페이지 장소 목록을 표시하기 위해 더보기만큼의 장소 개수를 불러오는 현상을 수정합니다.

## Key Changes 🔑
- optional(`?`) 매개변수를 사용하도록 코드 변경

## To Reviewers 🙏
