### PR TITLE
512 bug spot image

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/file/AttachFile.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/file/AttachFile.java
@@ -41,6 +41,11 @@ public class AttachFile {
     }
 
     public String getFileUrl() {
+        if(fileUrl.equals("")) return fileUrl;
+
         return "http://cdn.yigil.co.kr/" + fileUrl;
+    }
+    public static AttachFile of(String fileUrl) {
+        return new AttachFile(FileType.IMAGE, fileUrl, "", 0L);
     }
 }

--- a/backend/support/domain/src/main/java/kr/co/yigil/global/SortBy.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/global/SortBy.java
@@ -9,6 +9,7 @@ public enum SortBy {
     CREATED_AT("createdAt"),
     RATE("rate"),
     ID("id"),
+    PLACE_NAME("place.name"),
     LATEST_UPLOADED_TIME("latestUploadedTime");
 
     private String value;

--- a/backend/support/domain/src/main/java/kr/co/yigil/member/Member.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/member/Member.java
@@ -144,17 +144,6 @@ public class Member {
         }
     }
 
-    public String getProfileImageUrl() {
-        if (profileImageUrl == null) {
-            return null;
-        }
-        if (profileImageUrl.startsWith("http://") || profileImageUrl.startsWith("https://")) {
-            return profileImageUrl;
-        } else {
-            return DEFAULT_PROFILE_CDN + profileImageUrl;
-        }
-    }
-
     public List<Long> getFavoriteRegionIds() {
         return favoriteRegions.stream().map(
             memberRegion -> memberRegion.getRegion().getId()

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/Travel.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/Travel.java
@@ -40,7 +40,7 @@ public class Travel {
 
     @Column(nullable = false, length = 20)
     private String title;
-
+  
     @Column(columnDefinition = "TEXT")
     private String description;
 

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/CourseListDto.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/CourseListDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import lombok.Data;
 
 @Data
-public class CourseListDto {
+public class CourseListDto extends ImageFileDto{
 
     private final Long courseId;
     private final String title;
@@ -21,7 +21,7 @@ public class CourseListDto {
         this.courseId = courseId;
         this.title = title;
         this.rate = rate;
-        this.mapStaticImageUrl = mapStaticImageUrl;
+        this.mapStaticImageUrl = getImageUrl(mapStaticImageUrl);
         this.spotCount = spotCount;
         this.createdDate = createdDate;
         this.isPrivate = isPrivate;

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/ImageFileDto.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/ImageFileDto.java
@@ -1,0 +1,14 @@
+package kr.co.yigil.travel.domain.dto;
+
+public abstract class ImageFileDto {
+    protected String getImageUrl(String imageUrl){
+        if(imageUrl == null){
+            return null;
+        }
+        if(imageUrl.startsWith("http://") || imageUrl.startsWith("https://")){
+            return imageUrl;
+        }
+        return "http://cdn.yigil.co.kr/"+imageUrl;
+    }
+
+}

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/SpotListDto.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/dto/SpotListDto.java
@@ -5,26 +5,27 @@ import java.time.LocalDateTime;
 import lombok.Data;
 
 @Data
-public class SpotListDto {
+public class SpotListDto extends ImageFileDto {
 
     private final Long spotId;
     private final Long placeId;
-    private final String title;
+    private final String placeName;
     private final double rate;
     private final String imageUrl;
     private final LocalDateTime createdDate;
     private final Boolean isPrivate;
 
     @QueryProjection
-    public SpotListDto(Long spotId, Long placeId, String title, double rate, String imageUrl,
+    public SpotListDto(Long spotId, Long placeId, String placeName, double rate, String imageUrl,
         LocalDateTime createdDate, Boolean isPrivate) {
         this.spotId = spotId;
         this.placeId = placeId;
-        this.title = title;
+        this.placeName = placeName;
         this.rate = rate;
-        this.imageUrl = imageUrl;
+        this.imageUrl = getImageUrl(imageUrl);
         this.createdDate = createdDate;
         this.isPrivate = isPrivate;
     }
+
 
 }

--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/infrastructure/SpotQueryDslRepository.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/infrastructure/SpotQueryDslRepository.java
@@ -53,7 +53,7 @@ public class SpotQueryDslRepository {
                 new QSpotListDto(
                     spot.id,
                     spot.place.id,
-                    spot.title,
+                    spot.place.name,
                     spot.rate,
                     spot.place.imageFile.fileUrl,
                     spot.createdAt,

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/domain/MemberInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/domain/MemberInfo.java
@@ -20,7 +20,7 @@ public class MemberInfo {
         private final String email;
         private final String nickname;
         private final String profileImageUrl;
-        private final String age;
+        private final String ages;
         private final String gender;
         private final List<FavoriteRegionInfo> favoriteRegions;
         private final int followingCount;
@@ -31,7 +31,7 @@ public class MemberInfo {
             this.email = member.getEmail();
             this.nickname = member.getNickname();
             this.profileImageUrl = member.getProfileImageUrl();
-            this.age = member.getAges().getViewName();
+            this.ages = member.getAges().getViewName();
             this.gender = member.getGender().getViewName();
             this.followingCount = followCount.getFollowingCount();
             this.followerCount = followCount.getFollowerCount();

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/interfaces/dto/MemberDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/interfaces/dto/MemberDto.java
@@ -37,7 +37,7 @@ public class MemberDto {
         private final String email;
         private final String nickname;
         private final String profileImageUrl;
-        private final String age;
+        private final String ages;
         private final String gender;
         private final List<FavoriteRegion> favoriteRegions;
         private final int followingCount;

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotInfo.java
@@ -73,7 +73,7 @@ public class SpotInfo {
 
         private final Long spotId;
         private final Long placeId;
-        private final String title;
+        private final String placeName;
         private final double rate;
         private final String imageUrl;
         private final LocalDateTime createdDate;
@@ -82,7 +82,7 @@ public class SpotInfo {
         public SpotListInfo(SpotListDto spot) {
             this.spotId = spot.getSpotId();
             this.placeId = spot.getPlaceId();
-            this.title = spot.getTitle();
+            this.placeName = spot.getPlaceName();
             this.rate = spot.getRate();
             this.imageUrl = spot.getImageUrl();
             this.createdDate = spot.getCreatedDate();

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/response/MySpotsResponseDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/response/MySpotsResponseDto.java
@@ -20,7 +20,7 @@ public class MySpotsResponseDto {
 
         private final Long spotId;
         private final Long placeId;
-        private final String title;
+        private final String placeName;
         private final double rate;
         private final String imageUrl;
         private final String createdDate;

--- a/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
@@ -73,7 +73,7 @@ class MemberApiControllerTest {
             .email("test@yigil.co.kr")
             .nickname("test user")
             .profileImageUrl("https://cdn.igil.co.kr/images/profile.jpg")
-            .age("10대")
+            .ages("10대")
             .gender("남성")
             .favoriteRegions(List.of(favoriteRegion1, favoriteRegion2))
             .followerCount(10)
@@ -94,7 +94,7 @@ class MemberApiControllerTest {
                     fieldWithPath("email").description("이메일"),
                     fieldWithPath("nickname").description("닉네임"),
                     fieldWithPath("profile_image_url").description("프로필 이미지 URL"),
-                    fieldWithPath("age").description("연령대"),
+                    fieldWithPath("ages").description("연령대"),
                     fieldWithPath("gender").description("성별"),
                     fieldWithPath("favorite_regions").description("좋아하는 지역리스트"),
                     fieldWithPath("favorite_regions[].id").description("좋아하는 지역 ID"),
@@ -127,7 +127,7 @@ class MemberApiControllerTest {
         );
         String requestJson = "{\n"
             + "  \"nickname\": \"nickname\",\n"
-            + "  \"age\": \"10대\",\n"
+            + "  \"ages\": \"10대\",\n"
             + "  \"gender\": \"남성\",\n"
             + "  \"favoriteRegionIds\": [1, 2, 3]\n"
             + "}";
@@ -147,7 +147,7 @@ class MemberApiControllerTest {
                 ),
                 requestFields(
                     fieldWithPath("nickname").description("닉네임"),
-                    fieldWithPath("age").description("연령대"),
+                    fieldWithPath("ages").description("연령대"),
                     fieldWithPath("gender").description("성별"),
                     fieldWithPath("favoriteRegionIds").description("좋아하는 지역 ID 리스트")
                 ),
@@ -201,7 +201,7 @@ class MemberApiControllerTest {
             .nickname("test user")
             .profileImageUrl("https://cdn.yigil.co.kr/images/profile.jpg")
             .favoriteRegions(List.of(favoriteRegion1, favoriteRegion2))
-            .age("10대")
+            .ages("10대")
             .gender("남성")
             .followerCount(10)
             .followingCount(20)
@@ -224,7 +224,7 @@ class MemberApiControllerTest {
                     fieldWithPath("email").description("이메일"),
                     fieldWithPath("nickname").description("닉네임"),
                     fieldWithPath("profile_image_url").description("프로필 이미지 URL"),
-                    fieldWithPath("age").description("연령대"),
+                    fieldWithPath("ages").description("연령대"),
                     fieldWithPath("gender").description("성별"),
                     fieldWithPath("favorite_regions").description("좋아하는 지역리스트"),
                     fieldWithPath("favorite_regions[].id").description("좋아하는 지역 ID"),

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
@@ -324,7 +324,8 @@ class SpotApiControllerTest {
 
         MySpotsResponseDto.SpotInfo spotInfo = MySpotsResponseDto.SpotInfo.builder()
             .spotId(1L)
-            .title("test course")
+            .placeId(1L)
+            .placeName("test course")
             .rate(4.5)
             .imageUrl("images/map.jpg")
             .createdDate("2024-01-01")
@@ -365,7 +366,7 @@ class SpotApiControllerTest {
                 responseFields(
                     fieldWithPath("content[].spot_id").description("게시글(리뷰) ID"),
                     fieldWithPath("content[].place_id").description("장소 ID"),
-                    fieldWithPath("content[].title").description("장소 제목"),
+                    fieldWithPath("content[].place_name").description("장소 제목"),
                     fieldWithPath("content[].rate").description("장소 평점"),
                     fieldWithPath("content[].image_url").description("장소 이미지 URL"),
                     fieldWithPath("content[].created_date").description("장소 생성일"),


### PR DESCRIPTION
## Motivation 🧐

<br>

## Key Changes 🔑
- querydsl을 적용하면서 내 정보 조회 spot image에 cdn이 붙지 않고 전달되는 문제 해결
- 내 정보에서 프로필 이미지를 없애는 기능을 추가하였습니다. (빈 문자열로 저장하고 빈 문자열을 전달합니다.
- 내 정보 조회에서 연령대의 필드 이름이 age로 되어 있던 부분을 ages 로 수정하였습니다.

<br>

## To Reviewers 🙏
