### PR TITLE
524 member mypage

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/member/Member.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/member/Member.java
@@ -114,8 +114,10 @@ public class Member {
         this.modifiedAt = LocalDateTime.now();
     }
 
-    public Member(final Long id, final String email, final String socialLoginId, final String nickname,
-        final String profileImageUrl, final SocialLoginType socialLoginType, final Ages ages, final Gender gender) {
+    public Member(final Long id, final String email, final String socialLoginId,
+        final String nickname,
+        final String profileImageUrl, final SocialLoginType socialLoginType, final Ages ages,
+        final Gender gender) {
         this.id = id;
         this.email = email;
         this.socialLoginId = socialLoginId;
@@ -132,13 +134,19 @@ public class Member {
     public void updateMemberInfo(final String nickname, final String age, final String gender,
         final AttachFile profileImageFile, final List<MemberRegion> favoriteRegions) {
 
-        if (nickname != null) this.nickname = nickname;
-        if(age != null) this.ages = Ages.from(age);
-        if(gender != null) this.gender = Gender.from(gender);
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (age != null) {
+            this.ages = Ages.from(age);
+        }
+        if (gender != null) {
+            this.gender = Gender.from(gender);
+        }
         if (profileImageFile != null) {
             this.profileImageUrl = profileImageFile.getFileUrl();
         }
-        if(favoriteRegions != null) {
+        if (favoriteRegions != null) {
             this.favoriteRegions.clear();
             this.favoriteRegions.addAll(favoriteRegions);
         }

--- a/backend/support/domain/src/main/java/kr/co/yigil/region/domain/Region.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/region/domain/Region.java
@@ -1,5 +1,6 @@
 package kr.co.yigil.region.domain;
 
+import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,4 +34,8 @@ public class Region {
 
     @OneToMany(mappedBy = "region", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, orphanRemoval = true)
     private final List<MemberRegion> members = new ArrayList<>();
+
+    public String getName(){
+        return StringUtils.isEmpty(getName2()) ? getName1() : getName1() + " | " + getName2();
+    }
 }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/domain/MemberCommand.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/domain/MemberCommand.java
@@ -18,6 +18,7 @@ public class MemberCommand {
         private String gender;
         private MultipartFile profileImageFile;
         private List<Long> favoriteRegionIds;
+        private Boolean isProfileEmpty;
     }
 
 }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/domain/MemberInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/domain/MemberInfo.java
@@ -49,8 +49,7 @@ public class MemberInfo {
 
         public FavoriteRegionInfo(Region region) {
             this.id = region.getId();
-            String name2 = region.getName2()!=null? "|"+ region.getName2() : "";
-            this.name = region.getName1() + name2;
+            this.name = region.getName();
         }
     }
 

--- a/backend/yigil-api/src/main/java/kr/co/yigil/member/interfaces/dto/MemberDto.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/member/interfaces/dto/MemberDto.java
@@ -26,6 +26,7 @@ public class MemberDto {
         private String gender;
         private MultipartFile profileImageFile;
         private List<Long> favoriteRegionIds;
+        private Boolean isProfileEmpty;
     }
 
     @Getter

--- a/backend/yigil-api/src/main/java/kr/co/yigil/region/domain/RegionInfo.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/region/domain/RegionInfo.java
@@ -16,7 +16,7 @@ public class RegionInfo {
 
         public Main(Region region) {
             id = region.getId();
-            name = StringUtils.isEmpty(region.getName2()) ? region.getName1() : region.getName1() + " | " + region.getName2();
+            name = region.getName();
         }
     }
 

--- a/backend/yigil-api/src/test/java/kr/co/yigil/member/domain/MemberServiceImplTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/member/domain/MemberServiceImplTest.java
@@ -1,13 +1,26 @@
 package kr.co.yigil.member.domain;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
-
+import kr.co.yigil.file.AttachFile;
+import kr.co.yigil.file.FileUploader;
+import kr.co.yigil.follow.domain.FollowCount;
+import kr.co.yigil.follow.domain.FollowReader;
 import kr.co.yigil.member.Ages;
 import kr.co.yigil.member.Gender;
+import kr.co.yigil.member.Member;
+import kr.co.yigil.member.SocialLoginType;
+import kr.co.yigil.member.domain.MemberCommand.MemberUpdateRequest;
+import kr.co.yigil.region.domain.Region;
+import kr.co.yigil.region.domain.RegionReader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,14 +29,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
-
-import kr.co.yigil.file.AttachFile;
-import kr.co.yigil.file.FileUploader;
-import kr.co.yigil.follow.domain.FollowCount;
-import kr.co.yigil.follow.domain.FollowReader;
-import kr.co.yigil.member.Member;
-import kr.co.yigil.member.domain.MemberCommand.MemberUpdateRequest;
-import kr.co.yigil.region.domain.RegionReader;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceImplTest {
@@ -88,16 +93,76 @@ class MemberServiceImplTest {
         when(fileUploader.upload(mockFile)).thenReturn(mockAttachFile);
 
         memberService.updateMemberInfo(memberId, request);
-        verify(mockMember).updateMemberInfo(anyString(), anyString(), anyString(), any(AttachFile.class), anyList());
+        verify(mockMember).updateMemberInfo(anyString(), anyString(), anyString(),
+            any(AttachFile.class), anyList());
+    }
+
+    @DisplayName("imageFile 이 null 일 때 멤버의 프로필 이미지가 그대로인지 확인")
+    @Test
+    void GivenImageFileIsNull_WhenMemberUpdate_ThenShouldNotUpateProfileImage() {
+        Long memberId = 1L;
+        Member member = new Member(memberId, "originalEmail", "socialLoginId", "originalNickname",
+            "profileImageUrl", SocialLoginType.KAKAO, Ages.TEENAGERS, Gender.FEMALE);
+        MemberUpdateRequest request = new MemberUpdateRequest("updatedNickname", "20", "male",
+            null, List.of(1L, 2L, 3L));
+
+        when(memberReader.getMember(memberId)).thenReturn(member);
+        when(regionReader.getRegions(request.getFavoriteRegionIds())).thenReturn(List.of(mock(
+            Region.class)));
+
+        memberService.updateMemberInfo(memberId, request);
+
+        assertThat(member.getProfileImageUrl()).isEqualTo("profileImageUrl");
+        assertThat(member.getNickname()).isEqualTo("updatedNickname");
+        assertThat(member.getAges()).isEqualTo(Ages.TWENTIES);
+        assertThat(member.getGender()).isEqualTo(Gender.MALE);
+    }
+
+    @DisplayName("imageFile 이 null이 아니고 filename이 빈스트링 일 때 member의 profileImageUrl 이 빈스트링으로 업데이트 되는지 확인")
+    @Test
+    void GivenImageFileIsNull_WhenMemberUpdate_ThenProfileImageShouldEmptyString() {
+        Long memberId = 1L;
+        MultipartFile mockFile = new MockMultipartFile("file", "",
+            "image/jpeg",
+            "test".getBytes());
+
+        Member member = new Member(memberId, "originalEmail", "socialLoginId", "originalNickname",
+            "profileImageUrl", SocialLoginType.KAKAO, Ages.TEENAGERS, Gender.FEMALE);
+        MemberUpdateRequest request = new MemberUpdateRequest(null, null, null,
+            mockFile, null);
+        when(memberReader.getMember(memberId)).thenReturn(member);
+
+        memberService.updateMemberInfo(memberId, request);
+
+        assertThat(member.getProfileImageUrl()).isEqualTo("");
+    }
+    @DisplayName("imageFile 이 null이 아니고 filename이 빈스트링 일 때 member의 profileImageUrl 이 빈스트링으로 업데이트 되는지 확인")
+    @Test
+    void GivenImageFileIsNotNull_WhenMemberUpdate_ThenProfileImageShouldNotEmptyString() {
+        Long memberId = 1L;
+        MultipartFile mockFile = new MockMultipartFile("file", "test.jpg",
+            "image/jpeg",
+            "test".getBytes());
+
+        Member member = new Member(memberId, "originalEmail", "socialLoginId", "originalNickname",
+            "profileImageUrl", SocialLoginType.KAKAO, Ages.TEENAGERS, Gender.FEMALE);
+        MemberUpdateRequest request = new MemberUpdateRequest(null, null, null,
+            mockFile, null);
+        when(memberReader.getMember(memberId)).thenReturn(member);
+        when(fileUploader.upload(mockFile)).thenReturn(AttachFile.of("differentProfileImageUrl"));
+
+        memberService.updateMemberInfo(memberId, request);
+
+        assertThat(member.getProfileImageUrl()).isNotEqualTo("profileImageUrl");
     }
 
     @DisplayName("nicknameDuplicateCheck 를 호출했을 때 닉네임 중복 체크가 잘 되는지 확인")
-	@Test
-	void whenNicknameDuplicateCheck() {
+    @Test
+    void whenNicknameDuplicateCheck() {
         String nickname = "nickname";
         when(memberReader.existsByNickname(nickname)).thenReturn(false);
         MemberInfo.NicknameCheckInfo result = memberService.nicknameDuplicateCheck(nickname);
         assertThat(result).isNotNull().isInstanceOf(MemberInfo.NicknameCheckInfo.class);
         assertThat(result.isAvailable()).isTrue();
-	}
+    }
 }

--- a/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
@@ -131,7 +131,8 @@ class MemberApiControllerTest {
               "nickname": "nickname",
               "ages": "10대",
               "gender": "남성",
-              "favoriteRegionIds": [1, 2, 3]
+              "favoriteRegionIds": [1, 2, 3],
+              "isProfileEmpty": false
             }""";
 
         mockMvc.perform(multipart("/api/v1/members")
@@ -151,7 +152,8 @@ class MemberApiControllerTest {
                     fieldWithPath("nickname").description("닉네임"),
                     fieldWithPath("ages").description("연령대"),
                     fieldWithPath("gender").description("성별"),
-                    fieldWithPath("favoriteRegionIds").description("좋아하는 지역 ID 리스트")
+                    fieldWithPath("favoriteRegionIds").description("좋아하는 지역 ID 리스트"),
+                    fieldWithPath("isProfileEmpty").description("프로필 이미지를 삭제하는지 여부")
                 ),
                 responseFields(
                     fieldWithPath("message").description("메시지")

--- a/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/member/interfaces/controller/MemberApiControllerTest.java
@@ -73,8 +73,8 @@ class MemberApiControllerTest {
             .email("test@yigil.co.kr")
             .nickname("test user")
             .profileImageUrl("https://cdn.igil.co.kr/images/profile.jpg")
-            .ages("10대")
-            .gender("남성")
+            .ages("10")
+            .gender("female")
             .favoriteRegions(List.of(favoriteRegion1, favoriteRegion2))
             .followerCount(10)
             .followingCount(20)
@@ -114,7 +114,7 @@ class MemberApiControllerTest {
         MultipartFile multipartFile = new MockMultipartFile(
             "profileImageFile",          // 필드 이름
             "hello.txt",                  // 원본 파일 이름
-            "image/jpeg",   // 컨텐츠 타입
+            MediaType.IMAGE_JPEG_VALUE,   // 컨텐츠 타입
             "Hello, World!".getBytes()    // 파일 내용
         );
 
@@ -125,12 +125,14 @@ class MemberApiControllerTest {
                 .message("회원 정보 업데이트 성공")
                 .build()
         );
-        String requestJson = "{\n"
-            + "  \"nickname\": \"nickname\",\n"
-            + "  \"ages\": \"10대\",\n"
-            + "  \"gender\": \"남성\",\n"
-            + "  \"favoriteRegionIds\": [1, 2, 3]\n"
-            + "}";
+
+        String requestJson = """
+              {
+              "nickname": "nickname",
+              "ages": "10대",
+              "gender": "남성",
+              "favoriteRegionIds": [1, 2, 3]
+            }""";
 
         mockMvc.perform(multipart("/api/v1/members")
                 .file("profileImageFile", multipartFile.getBytes())
@@ -201,8 +203,8 @@ class MemberApiControllerTest {
             .nickname("test user")
             .profileImageUrl("https://cdn.yigil.co.kr/images/profile.jpg")
             .favoriteRegions(List.of(favoriteRegion1, favoriteRegion2))
-            .ages("10대")
-            .gender("남성")
+            .ages("10")
+            .gender("male")
             .followerCount(10)
             .followingCount(20)
             .build();


### PR DESCRIPTION
## Motivation 🧐
멤버의 회원 정보 중 favorite place의 지역 이름 정보 변경
<br>

## Key Changes 🔑
- region 의 이름을 보여주는 부분을 region 엔티티 안에 getName()을 통해서 단일화 했습니다.
- profile 이미지를 없앨 경우 isProfileEmpty 필드를 true로 설정하도록 변경
- 이미지가 널이 아니고 isProfileEmpty 필드가 true일 경우 예외 발생 
- 프로필 이미지 관련 테스트 케이스를 추가하였습니다.

<br>

## To Reviewers 🙏
- 이상한 부분이 있으면 언제든지 말해주세요
-
