### PR TITLE
Spot/Course 추가 관련 리팩토링 및 기능 추가 - 2

### DIFF
--- a/frontend/src/app/_components/add/Navigation.tsx
+++ b/frontend/src/app/_components/add/Navigation.tsx
@@ -19,7 +19,11 @@ export default function Navigation() {
       <span className="text-xl text-semibold text-gray-900">
         {step.data.label}
       </span>
-      <button onClick={() => dispatch({ type: 'NEXT' })}>다음</button>
+      {step.data.value === 4 ? (
+        <button className="text-blue-500">확정</button>
+      ) : (
+        <button onClick={() => dispatch({ type: 'NEXT' })}>다음</button>
+      )}
     </nav>
   );
 }

--- a/frontend/src/app/_components/add/common/PostRating.tsx
+++ b/frontend/src/app/_components/add/common/PostRating.tsx
@@ -8,23 +8,22 @@ import StarIcon from '/public/icons/star.svg';
 import type { Dispatch } from 'react';
 import type { EventFor } from '@/types/type';
 import type { TAddSpotAction } from '../spot/SpotContext';
+import { TReview } from '@/context/travel/schema';
 
-export default function PostRating({
-  dispatch,
-}: {
-  dispatch: Dispatch<TAddSpotAction>;
+export default function PostRating({}: {
+  // setReview: (nextReview: TReview)
 }) {
   const addSpotState = useContext(AddSpotContext);
 
   const [hoverValue, setHoverValue] = useState(1);
 
-  const onMouseEnter = (e: EventFor<'div', 'onKeyDown'>, value: number) => {
-    e.key === 'Enter' && dispatch({ type: 'SET_RATING', payload: value });
-  };
+  // const onMouseEnter = (e: EventFor<'div', 'onKeyDown'>, value: number) => {
+  //   e.key === 'Enter' && dispatch({ type: 'SET_RATING', payload: value });
+  // };
 
-  const onClickStar = (value: number) => {
-    dispatch({ type: 'SET_RATING', payload: value });
-  };
+  // const onClickStar = (value: number) => {
+  //   dispatch({ type: 'SET_RATING', payload: value });
+  // };
 
   const onHoverStar = (value: number) => {
     setHoverValue(value);
@@ -32,7 +31,7 @@ export default function PostRating({
 
   return (
     <div className="flex justify-center items-center text-2xl gap-x-6">
-      {[...Array(5)].map((_, i) => (
+      {/* {[...Array(5)].map((_, i) => (
         <div key={i} tabIndex={0} onKeyDown={(e) => onMouseEnter(e, i + 1)}>
           <label htmlFor={`rate${i + 1}`}>
             <input
@@ -40,7 +39,7 @@ export default function PostRating({
               type="radio"
               id={`rate${i + 1}`}
               value={i + 1}
-              onClick={() => onClickStar(i + 1)}
+              // onClick={() => onClickStar(i + 1)}
             />
             <StarIcon
               className={`cursor-pointer w-12 h-12 transition-all delay-80 ${
@@ -55,7 +54,7 @@ export default function PostRating({
             />
           </label>
         </div>
-      ))}
+      ))} */}
     </div>
   );
 }

--- a/frontend/src/app/_components/add/common/PostReview.tsx
+++ b/frontend/src/app/_components/add/common/PostReview.tsx
@@ -60,8 +60,15 @@ export default function PostReview({
 
     const nextReview: TReview = {
       ...review,
-      content: value,
     };
+
+    if (e.currentTarget.type === 'text') {
+      nextReview.title = value;
+    }
+
+    if (e.currentTarget.type === 'textarea') {
+      nextReview.content = value;
+    }
 
     setReview(nextReview);
   };

--- a/frontend/src/app/_components/add/common/PostReview.tsx
+++ b/frontend/src/app/_components/add/common/PostReview.tsx
@@ -1,23 +1,53 @@
 'use client';
 
-import { useContext } from 'react';
+import { useState } from 'react';
 
-import { AddSpotContext } from '../spot/SpotContext';
+import StarIcon from '/public/icons/star.svg';
 
-import type { Dispatch } from 'react';
 import type { EventFor } from '@/types/type';
-
-import type { TAddSpotAction } from '../spot/SpotContext';
+import type { TReview } from '@/context/travel/schema';
 
 interface TPostReviewProps {
   viewTitle?: boolean;
-  dispatch: Dispatch<TAddSpotAction>;
+  review: TReview;
+  setReview: (nextReview: TReview) => void;
 }
 
-export default function PostReview({ viewTitle, dispatch }: TPostReviewProps) {
-  const { review } = useContext(AddSpotContext);
-
+export default function PostReview({
+  viewTitle,
+  review,
+  setReview,
+}: TPostReviewProps) {
   const maxLength = 30;
+
+  const [hoverValue, setHoverValue] = useState(1);
+
+  const onSetStar = (value: number) => {
+    const nextReview: TReview = {
+      ...review,
+      rate: value,
+    };
+
+    setReview(nextReview);
+  };
+
+  const onKeydown = (e: EventFor<'div', 'onKeyDown'>, value: number) => {
+    if (e.key === 'Enter') {
+      onSetStar(value);
+      return;
+    }
+  };
+
+  const onKeyUp = (e: EventFor<'div', 'onKeyUp'>, value: number) => {
+    if (e.key === 'Tab') {
+      onHoverStar(value);
+      return;
+    }
+  };
+
+  const onHoverStar = (value: number) => {
+    setHoverValue(value);
+  };
 
   const onChangeReview = (e: EventFor<'input' | 'textarea', 'onChange'>) => {
     const { name, value } = e.currentTarget;
@@ -28,11 +58,47 @@ export default function PostReview({ viewTitle, dispatch }: TPostReviewProps) {
       return;
     }
 
-    dispatch({ type: 'SET_REVIEW', payload: { ...review, [name]: value } });
+    const nextReview: TReview = {
+      ...review,
+      content: value,
+    };
+
+    setReview(nextReview);
   };
 
   return (
-    <form className="flex flex-col items-center gap-y-2 px-[22px]">
+    <section className="px-4 flex flex-col items-center gap-8">
+      <div className="flex justify-center items-center text-2xl gap-x-6">
+        {[...Array(5)].map((_, i) => (
+          <div
+            key={i}
+            tabIndex={0}
+            onKeyDown={(e) => onKeydown(e, i + 1)}
+            onKeyUp={(e) => onKeyUp(e, i + 1)}
+          >
+            <label htmlFor={`rate${i + 1}`}>
+              <input
+                className="hidden"
+                type="radio"
+                id={`rate${i + 1}`}
+                value={i + 1}
+                onClick={() => onSetStar(i + 1)}
+              />
+              <StarIcon
+                className={`cursor-pointer w-12 h-12 transition-all delay-80 ${
+                  i + 1 <= hoverValue
+                    ? ' fill-[#FAbb15]'
+                    : i + 1 <= review.rate
+                    ? 'fill-[#FACC15]'
+                    : 'fill-gray-200'
+                } `}
+                onMouseEnter={() => onHoverStar(i + 1)}
+                onMouseLeave={() => setHoverValue(0)}
+              />
+            </label>
+          </div>
+        ))}
+      </div>
       {viewTitle && (
         <input
           className="w-full py-3 px-4 bg-gray-100 rounded-xl text-xl leading-0"
@@ -53,11 +119,11 @@ export default function PostReview({ viewTitle, dispatch }: TPostReviewProps) {
           maxLength={maxLength}
           required
           onChange={onChangeReview}
-          value={review.review}
+          value={review.content}
           placeholder="간단한 리뷰를 작성하세요.(최대 30자)"
         />
-        <p className="flex justify-end text-gray-400 mr-4">{`${review.review.length} / 30`}</p>
+        <p className="flex justify-end text-gray-400 mr-4">{`${review.content.length} / 30`}</p>
       </div>
-    </form>
+    </section>
   );
 }

--- a/frontend/src/app/_components/add/common/PostReview.tsx
+++ b/frontend/src/app/_components/add/common/PostReview.tsx
@@ -67,7 +67,7 @@ export default function PostReview({
   };
 
   return (
-    <section className="px-4 flex flex-col items-center gap-8">
+    <section className="p-4 flex flex-col items-center gap-8">
       <div className="flex justify-center items-center text-2xl gap-x-6">
         {[...Array(5)].map((_, i) => (
           <div

--- a/frontend/src/app/_components/add/course/AddCourseConfirm.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseConfirm.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useContext } from 'react';
+import { CourseContext } from '@/context/travel/course/CourseContext';
+
+export default function AddCourseConfirm() {
+  const [] = useContext(CourseContext);
+
+  return <section className="flex flex-col grow"></section>;
+}

--- a/frontend/src/app/_components/add/course/AddCourseConfirm.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseConfirm.tsx
@@ -1,10 +1,61 @@
 'use client';
 
+import Image from 'next/image';
+
 import { useContext } from 'react';
 import { CourseContext } from '@/context/travel/course/CourseContext';
 
-export default function AddCourseConfirm() {
-  const [] = useContext(CourseContext);
+import IconWithCounts from '../../IconWithCounts';
 
-  return <section className="flex flex-col grow"></section>;
+import StarIcon from '/public/icons/star.svg';
+import PlaceholderImage from '/public/images/placeholder.png';
+import AddCourseSpots from './AddCourseSpots';
+
+const tempImage =
+  'http://cdn.yigil.co.kr/images/a188a3e6-6a33-4013-b97d-103d570f958a_%EC%86%94%ED%96%A5%EA%B8%B0%20%EC%A7%80%EB%8F%84%20%EC%9D%B4%EB%AF%B8%EC%A7%80.png';
+
+export default function AddCourseConfirm() {
+  const [course] = useContext(CourseContext);
+
+  const { spots, review } = course;
+
+  const currentDate = new Date(Date.now());
+
+  return (
+    <section className="px-4 flex flex-col grow">
+      <div className="px-2 py-4 flex justify-between">
+        <span className="text-2xl font-semibold">{review.title}</span>
+        <span className="flex items-center">
+          <IconWithCounts
+            icon={
+              <StarIcon className="w-4 h-4 stroke-[#FACC15] fill-[#FACC15]" />
+            }
+            count={review.rate}
+            rating
+          />
+        </span>
+      </div>
+      <AddCourseSpots spots={spots} />
+      {/* 경로 이미지 */}
+      <div className="my-4 relative aspect-video">
+        <Image
+          className="rounded-xl object-cover"
+          priority
+          src={tempImage}
+          placeholder="blur"
+          blurDataURL={PlaceholderImage.blurDataURL}
+          alt={`${review.title} 경로 이미지`}
+          fill
+        />
+      </div>
+      <span className="self-end text-gray-400 font-medium">
+        {currentDate.toLocaleDateString()}
+      </span>
+      <div className="my-4 h-36">
+        <div className="h-full p-4 rounded-xl bg-gray-100">
+          {review.content}
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/frontend/src/app/_components/add/course/AddCourseData.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseData.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { StepContext } from '@/context/travel/step/StepContext';
-import { CourseContext } from '@/context/travel/course/CourseContext';
 
 import AddCoursePlace from './AddCoursePlace';
 import AddCourseImages from './AddCourseImages';
@@ -10,17 +9,6 @@ import AddCourseReview from './AddCourseReviews';
 
 export default function AddCourseData() {
   const [step] = useContext(StepContext);
-  const [course] = useContext(CourseContext);
-
-  const [index, setIndex] = useState(0);
-
-  function selectIndex(nextIndex: number) {
-    if (nextIndex < 0 || nextIndex >= course.spots.length) {
-      return;
-    }
-
-    setIndex(nextIndex);
-  }
 
   const { label, value } = step.data;
 
@@ -30,9 +18,9 @@ export default function AddCourseData() {
     case 1:
       return <AddCoursePlace />;
     case 2:
-      return <AddCourseImages index={index} selectIndex={selectIndex} />;
+      return <AddCourseImages />;
     case 3:
-      return <AddCourseReview index={index} selectIndex={selectIndex} />;
+      return <AddCourseReview />;
     case 4:
       return <>{label}</>;
   }

--- a/frontend/src/app/_components/add/course/AddCourseData.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseData.tsx
@@ -1,10 +1,26 @@
 'use client';
 
+import { useContext, useState } from 'react';
 import { StepContext } from '@/context/travel/step/StepContext';
-import { useContext } from 'react';
+import { CourseContext } from '@/context/travel/course/CourseContext';
+
+import AddCoursePlace from './AddCoursePlace';
+import AddCourseImages from './AddCourseImages';
+import AddCourseReview from './AddCourseReviews';
 
 export default function AddCourseData() {
   const [step] = useContext(StepContext);
+  const [course] = useContext(CourseContext);
+
+  const [index, setIndex] = useState(0);
+
+  function selectIndex(nextIndex: number) {
+    if (nextIndex < 0 || nextIndex >= course.spots.length) {
+      return;
+    }
+
+    setIndex(nextIndex);
+  }
 
   const { label, value } = step.data;
 
@@ -12,11 +28,11 @@ export default function AddCourseData() {
     case 0:
       return <>{label}</>;
     case 1:
-      return <>{label}</>;
+      return <AddCoursePlace />;
     case 2:
-      return <>{label}</>;
+      return <AddCourseImages index={index} selectIndex={selectIndex} />;
     case 3:
-      return <>{label}</>;
+      return <AddCourseReview index={index} selectIndex={selectIndex} />;
     case 4:
       return <>{label}</>;
   }

--- a/frontend/src/app/_components/add/course/AddCourseData.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseData.tsx
@@ -6,6 +6,7 @@ import { StepContext } from '@/context/travel/step/StepContext';
 import AddCoursePlace from './AddCoursePlace';
 import AddCourseImages from './AddCourseImages';
 import AddCourseReview from './AddCourseReviews';
+import AddCourseConfirm from './AddCourseConfirm';
 
 export default function AddCourseData() {
   const [step] = useContext(StepContext);
@@ -22,6 +23,6 @@ export default function AddCourseData() {
     case 3:
       return <AddCourseReview />;
     case 4:
-      return <>{label}</>;
+      return <AddCourseConfirm />;
   }
 }

--- a/frontend/src/app/_components/add/course/AddCourseImages.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseImages.tsx
@@ -21,8 +21,10 @@ export default function AddCourseImages() {
       <SelectSpot key="images" index={index} selectIndex={selectIndex} />
       {index !== -1 && (
         <div className="p-4 flex justify-between items-center">
-          <span className="text-gray-400">이름</span>
-          <span className="text-xl">{state.spots[index].place.name}</span>
+          <span className="pr-8 text-lg text-gray-400 shrink-0">이름</span>
+          <span className="text-2xl font-medium">
+            {state.spots[index].place.name}
+          </span>
         </div>
       )}
       <CourseImageHandler order={index} />

--- a/frontend/src/app/_components/add/course/AddCourseImages.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseImages.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useContext, useState } from 'react';
+import CourseImageHandler from '../../images/CourseImageHandler';
+import { InfoTitle } from '../common';
+import { CourseContext } from '@/context/travel/course/CourseContext';
+
+export default function AddCourseImages({
+  index,
+  selectIndex,
+}: {
+  index: number;
+  selectIndex: (nextOrder: number) => void;
+}) {
+  const [state] = useContext(CourseContext);
+
+  return (
+    <section className="flex flex-col grow">
+      <InfoTitle label="사진" additionalLabel="을 업로드하세요." />
+      {/* 특정 장소 선택 UI */}
+      <div className="flex flex-col">
+        <button onClick={() => selectIndex(index - 1)}>Previous</button>
+        <button onClick={() => selectIndex(index + 1)}>Next</button>
+        <span>{`${index + 1} / ${state.spots.length}`}</span>
+      </div>
+      <div className="px-4 pb-4 flex justify-between items-center">
+        <span className="text-gray-400">이름</span>
+        <span className="text-xl">{state.spots[index].place.name}</span>
+      </div>
+      <CourseImageHandler order={index} />
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/course/AddCourseImages.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseImages.tsx
@@ -1,32 +1,30 @@
 'use client';
 
 import { useContext, useState } from 'react';
-import CourseImageHandler from '../../images/CourseImageHandler';
-import { InfoTitle } from '../common';
 import { CourseContext } from '@/context/travel/course/CourseContext';
 
-export default function AddCourseImages({
-  index,
-  selectIndex,
-}: {
-  index: number;
-  selectIndex: (nextOrder: number) => void;
-}) {
+import { InfoTitle } from '../common';
+import CourseImageHandler from '../../images/CourseImageHandler';
+import SelectSpot from './SelectSpot';
+
+export default function AddCourseImages() {
   const [state] = useContext(CourseContext);
+  const [index, setIndex] = useState(0);
+
+  function selectIndex(nextIndex: number) {
+    setIndex(nextIndex);
+  }
 
   return (
-    <section className="flex flex-col grow">
+    <section className="flex flex-col justify-center grow">
       <InfoTitle label="사진" additionalLabel="을 업로드하세요." />
-      {/* 특정 장소 선택 UI */}
-      <div className="flex flex-col">
-        <button onClick={() => selectIndex(index - 1)}>Previous</button>
-        <button onClick={() => selectIndex(index + 1)}>Next</button>
-        <span>{`${index + 1} / ${state.spots.length}`}</span>
-      </div>
-      <div className="px-4 pb-4 flex justify-between items-center">
-        <span className="text-gray-400">이름</span>
-        <span className="text-xl">{state.spots[index].place.name}</span>
-      </div>
+      <SelectSpot key="images" index={index} selectIndex={selectIndex} />
+      {index !== -1 && (
+        <div className="p-4 flex justify-between items-center">
+          <span className="text-gray-400">이름</span>
+          <span className="text-xl">{state.spots[index].place.name}</span>
+        </div>
+      )}
       <CourseImageHandler order={index} />
     </section>
   );

--- a/frontend/src/app/_components/add/course/AddCoursePlace.tsx
+++ b/frontend/src/app/_components/add/course/AddCoursePlace.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useContext } from 'react';
+import { CourseContext } from '@/context/travel/course/CourseContext';
+
+import type { TChoosePlace } from '@/context/travel/schema';
+
+const place: TChoosePlace = {
+  name: '선택한 장소',
+  address: '장소에 대한 도로명주소',
+  mapImageUrl: '장소 위치 지도 이미지',
+  coords: { lng: 35, lat: 125 },
+};
+
+export default function AddCoursePlace() {
+  const [, dispatch] = useContext(CourseContext);
+
+  return (
+    <section className="grow">
+      <button onClick={() => dispatch({ type: 'ADD_SPOT', payload: place })}>
+        GOGOGO!!!
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/course/AddCourseReviews.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseReviews.tsx
@@ -1,41 +1,52 @@
 'use client';
 
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { CourseContext } from '@/context/travel/course/CourseContext';
 import { InfoTitle, PostReview } from '../common';
+import SelectSpot from './SelectSpot';
 
 import type { TReview } from '@/context/travel/schema';
 
-export default function AddCourseReview({
-  index,
-  selectIndex,
-}: {
-  index: number;
-  selectIndex: (nextIndex: number) => void;
-}) {
+export default function AddCourseReview() {
   const [state, dispatch] = useContext(CourseContext);
+  const [index, setIndex] = useState(0);
+
+  function selectIndex(nextIndex: number) {
+    setIndex(nextIndex);
+  }
 
   function setReview(nextReview: TReview) {
-    if (nextReview.title) {
-      dispatch({ type: 'SET_COURSE_REVIEW', payload: nextReview });
-    }
-
     dispatch({ type: 'SET_SPOT_REVIEW', payload: { data: nextReview, index } });
+  }
+
+  function setCourseReview(nextReview: TReview) {
+    dispatch({ type: 'SET_COURSE_REVIEW', payload: nextReview });
   }
 
   return (
     <section className="flex flex-col justify-center grow">
       <InfoTitle label="리뷰" additionalLabel="를 남기세요." />
-      <div className="flex flex-col">
-        <button onClick={() => selectIndex(index - 1)}>Previous</button>
-        <button onClick={() => selectIndex(index + 1)}>Next</button>
-        <span>{`${index + 1} / ${state.spots.length}`}</span>
-      </div>
-      <div className="px-4 pb-4 flex justify-between items-center">
-        <span className="text-gray-400">이름</span>
-        <span className="text-xl">{state.spots[index].place.name}</span>
-      </div>
-      <PostReview review={state.spots[index].review} setReview={setReview} />
+      <SelectSpot
+        key="reviews"
+        index={index}
+        selectIndex={selectIndex}
+        review
+      />
+      {index !== -1 && (
+        <div className="p-4 flex justify-between items-center">
+          <span className="text-gray-400">이름</span>
+          <span className="text-xl">{state.spots[index].place.name}</span>
+        </div>
+      )}
+      {index === -1 ? (
+        <PostReview
+          review={state.review}
+          setReview={setCourseReview}
+          viewTitle
+        />
+      ) : (
+        <PostReview review={state.spots[index].review} setReview={setReview} />
+      )}
     </section>
   );
 }

--- a/frontend/src/app/_components/add/course/AddCourseReviews.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseReviews.tsx
@@ -34,8 +34,10 @@ export default function AddCourseReview() {
       />
       {index !== -1 && (
         <div className="p-4 flex justify-between items-center">
-          <span className="text-gray-400">이름</span>
-          <span className="text-xl">{state.spots[index].place.name}</span>
+          <span className="pr-8 text-lg text-gray-400 shrink-0">이름</span>
+          <span className="text-2xl font-medium">
+            {state.spots[index].place.name}
+          </span>
         </div>
       )}
       {index === -1 ? (

--- a/frontend/src/app/_components/add/course/AddCourseReviews.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseReviews.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useContext } from 'react';
+import { CourseContext } from '@/context/travel/course/CourseContext';
+import { InfoTitle, PostReview } from '../common';
+
+import type { TReview } from '@/context/travel/schema';
+
+export default function AddCourseReview({
+  index,
+  selectIndex,
+}: {
+  index: number;
+  selectIndex: (nextIndex: number) => void;
+}) {
+  const [state, dispatch] = useContext(CourseContext);
+
+  function setReview(nextReview: TReview) {
+    if (nextReview.title) {
+      dispatch({ type: 'SET_COURSE_REVIEW', payload: nextReview });
+    }
+
+    dispatch({ type: 'SET_SPOT_REVIEW', payload: { data: nextReview, index } });
+  }
+
+  return (
+    <section className="flex flex-col justify-center grow">
+      <InfoTitle label="리뷰" additionalLabel="를 남기세요." />
+      <div className="flex flex-col">
+        <button onClick={() => selectIndex(index - 1)}>Previous</button>
+        <button onClick={() => selectIndex(index + 1)}>Next</button>
+        <span>{`${index + 1} / ${state.spots.length}`}</span>
+      </div>
+      <div className="px-4 pb-4 flex justify-between items-center">
+        <span className="text-gray-400">이름</span>
+        <span className="text-xl">{state.spots[index].place.name}</span>
+      </div>
+      <PostReview review={state.spots[index].review} setReview={setReview} />
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/course/AddCourseSpotData.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseSpotData.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+
+import ImageCarousel from '../../ui/carousel/ImageCarousel';
+import IconWithCounts from '../../IconWithCounts';
+
+import ChevronDownIcon from '/public/icons/chevron-down.svg';
+import StarIcon from '/public/icons/star.svg';
+
+import type { TSpotState } from '@/context/travel/schema';
+
+export default function AddCourseSpotData({
+  spot,
+  index,
+}: {
+  spot: TSpotState;
+  index: number;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { place, images, review } = spot;
+
+  const imageUris = images.map((image) => image.uri);
+  const currentDate = new Date(Date.now());
+
+  return (
+    <article className="flex flex-col">
+      <button
+        className="px-4 py-2 w-full border border-gray-500 rounded-lg flex justify-between items-center"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex gap-4">
+          {/* ICON */}
+          <span>{place.name}</span>
+        </div>
+        <span>
+          <ChevronDownIcon
+            className={`w-4 h-4 stroke-gray-500 stroke-2 [stroke-linecap:round] [stroke-linejoin:round] ${
+              isOpen && 'rotate-180'
+            }`}
+          />
+        </span>
+      </button>
+      {isOpen && (
+        <section className="py-4 flex flex-col gap-4">
+          <div className="px-4 flex justify-between items-center">
+            <span className="text-gray-500 font-medium">{place.address}</span>
+            <span className="pl-4 shrink-0">
+              <IconWithCounts
+                icon={
+                  <StarIcon className="w-4 h-4 stroke-[#FACC15] fill-[#FACC15]" />
+                }
+                count={review.rate}
+                rating
+              />
+            </span>
+          </div>
+          <div className="pl-2">
+            <ImageCarousel images={imageUris} label="" variant="thumbnail" />
+          </div>
+          <span className="self-end text-gray-400 font-medium">
+            {currentDate.toLocaleDateString()}
+          </span>
+          <div className="h-36">
+            <div className="h-full p-4 rounded-xl bg-gray-100">
+              {review.content}
+            </div>
+          </div>
+        </section>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/app/_components/add/course/AddCourseSpots.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseSpots.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { TSpotState } from '@/context/travel/schema';
+import AddCourseSpotData from './AddCourseSpotData';
+
+export default function AddCourseSpots({ spots }: { spots: TSpotState[] }) {
+  return (
+    <section className="flex flex-col">
+      {spots.map((spot, index) => (
+        <div
+          className="flex flex-col"
+          key={`${spot.place.name}-${spot.place.address}-${index}`}
+        >
+          <AddCourseSpotData spot={spot} index={index} />
+          {index < spots.length - 1 && (
+            <div className="my-4 w-1 h-8 border-2 border-gray-300 self-center" />
+          )}
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/course/SelectSpot.tsx
+++ b/frontend/src/app/_components/add/course/SelectSpot.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useContext } from 'react';
+
+import { CourseContext } from '@/context/travel/course/CourseContext';
+import { SPOTS_COUNT } from '@/context/travel/schema';
+
+export default function SelectSpot({
+  index,
+  selectIndex,
+  review,
+}: {
+  index: number;
+  selectIndex: (nextIndex: number) => void;
+  review?: boolean;
+}) {
+  const [state] = useContext(CourseContext);
+
+  const indices = [...Array(SPOTS_COUNT)].map((_, i) => i);
+
+  return (
+    <nav className="p-4 flex gap-4 justify-center">
+      {indices.map((value) => (
+        <button
+          className={`w-12 h-12 text-xl rounded-full ${
+            value >= state.spots.length && 'text-gray-400'
+          } ${value === index && 'bg-blue-500 text-white'}`}
+          key={value}
+          disabled={value >= state.spots.length}
+          onClick={() => selectIndex(value)}
+        >
+          {value + 1}
+        </button>
+      ))}
+      {review && (
+        <button
+          className={`w-12 h-12 text-xl rounded-full ${
+            index === -1 && 'bg-blue-500 text-white'
+          }`}
+          onClick={() => selectIndex(-1)}
+        >
+          코스
+        </button>
+      )}
+    </nav>
+  );
+}

--- a/frontend/src/app/_components/add/spot/AddSpotConfirm.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotConfirm.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 
 import { useContext } from 'react';
 import { SpotContext } from '@/context/travel/spot/SpotContext';
-import { blobTodataUrl } from '@/utils';
 
 import IconWithCounts from '../../IconWithCounts';
 import ImageCarousel from '../../ui/carousel/ImageCarousel';
@@ -22,7 +21,7 @@ export default function AddSpotConfirm() {
 
   const uris = images.map((image) => image.uri);
 
-  const currentData = new Date(Date.now());
+  const currentDate = new Date(Date.now());
 
   return (
     <section className="flex flex-col justify-center grow">
@@ -54,7 +53,7 @@ export default function AddSpotConfirm() {
         <ImageCarousel images={uris} label="" variant="thumbnail" />
       </div>
       <span className="px-3 pb-2 self-end text-gray-400 font-medium">
-        {currentData.toLocaleDateString()}
+        {currentDate.toLocaleDateString()}
       </span>
       <div className="p-4 h-36">
         <div className="h-full p-4 rounded-xl bg-gray-100">

--- a/frontend/src/app/_components/add/spot/AddSpotConfirm.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotConfirm.tsx
@@ -4,11 +4,13 @@ import Image from 'next/image';
 
 import { useContext } from 'react';
 import { SpotContext } from '@/context/travel/spot/SpotContext';
+import { blobTodataUrl } from '@/utils';
 
 import IconWithCounts from '../../IconWithCounts';
 import ImageCarousel from '../../ui/carousel/ImageCarousel';
 
 import StarIcon from '/public/icons/star.svg';
+import PlaceholderImage from '/public/images/placeholder.png';
 
 const tempImage =
   'http://cdn.yigil.co.kr/images/a188a3e6-6a33-4013-b97d-103d570f958a_%EC%86%94%ED%96%A5%EA%B8%B0%20%EC%A7%80%EB%8F%84%20%EC%9D%B4%EB%AF%B8%EC%A7%80.png';
@@ -42,6 +44,8 @@ export default function AddSpotConfirm() {
           className="rounded-xl object-cover"
           priority
           src={tempImage}
+          placeholder="blur"
+          blurDataURL={PlaceholderImage.blurDataURL}
           alt={`${place.name} 지도 이미지`}
           fill
         />

--- a/frontend/src/app/_components/add/spot/AddSpotConfirm.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotConfirm.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Image from 'next/image';
+
+import { useContext } from 'react';
+import { SpotContext } from '@/context/travel/spot/SpotContext';
+
+import IconWithCounts from '../../IconWithCounts';
+import ImageCarousel from '../../ui/carousel/ImageCarousel';
+
+import StarIcon from '/public/icons/star.svg';
+
+const tempImage =
+  'http://cdn.yigil.co.kr/images/a188a3e6-6a33-4013-b97d-103d570f958a_%EC%86%94%ED%96%A5%EA%B8%B0%20%EC%A7%80%EB%8F%84%20%EC%9D%B4%EB%AF%B8%EC%A7%80.png';
+
+export default function AddSpotConfirm() {
+  const [spot] = useContext(SpotContext);
+
+  const { place, images, review } = spot;
+
+  const uris = images.map((image) => image.uri);
+
+  const currentData = new Date(Date.now());
+
+  return (
+    <section className="flex flex-col justify-center grow">
+      <div className="px-4 py-1 flex justify-between">
+        <span className="pl-2 text-2xl font-semibold">{place.name}</span>
+        <span>
+          <IconWithCounts
+            icon={
+              <StarIcon className="w-4 h-4 stroke-[#FACC15] fill-[#FACC15]" />
+            }
+            count={review.rate}
+            rating
+          />
+        </span>
+      </div>
+      <span className="px-6 py-4 text-gray-500">{place.address}</span>
+      <div className="mx-4 relative aspect-video">
+        <Image
+          className="rounded-xl object-cover"
+          priority
+          src={tempImage}
+          alt={`${place.name} 지도 이미지`}
+          fill
+        />
+      </div>
+      <div className="pl-4 py-4">
+        <ImageCarousel images={uris} label="" variant="thumbnail" />
+      </div>
+      <span className="px-3 pb-2 self-end text-gray-400 font-medium">
+        {currentData.toLocaleDateString()}
+      </span>
+      <div className="p-4 h-36">
+        <div className="h-full p-4 rounded-xl bg-gray-100">
+          {review.content}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/spot/AddSpotData.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotData.tsx
@@ -6,11 +6,12 @@ import { StepContext } from '@/context/travel/step/StepContext';
 import AddSpotPlace from './AddSpotPlace';
 import AddSpotImages from './AddSpotImages';
 import AddSpotReview from './AddSpotReview';
+import AddSpotConfirm from './AddSpotConfirm';
 
 export default function AddSpotData() {
   const [step] = useContext(StepContext);
 
-  const { label, value } = step.data;
+  const { value } = step.data;
 
   switch (value) {
     // Spot은 0번이 없음
@@ -23,6 +24,6 @@ export default function AddSpotData() {
     case 3:
       return <AddSpotReview />;
     case 4:
-      return <>{label}</>;
+      return <AddSpotConfirm />;
   }
 }

--- a/frontend/src/app/_components/add/spot/AddSpotData.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotData.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import { StepContext } from '@/context/travel/step/StepContext';
 import { useContext } from 'react';
+import { StepContext } from '@/context/travel/step/StepContext';
+
+import AddSpotPlace from './AddSpotPlace';
+import AddSpotImages from './AddSpotImages';
+import AddSpotReview from './AddSpotReview';
 
 export default function AddSpotData() {
   const [step] = useContext(StepContext);
@@ -13,11 +17,11 @@ export default function AddSpotData() {
     case 0:
       return <></>;
     case 1:
-      return <>{label}</>;
+      return <AddSpotPlace />;
     case 2:
-      return <>{label}</>;
+      return <AddSpotImages />;
     case 3:
-      return <>{label}</>;
+      return <AddSpotReview />;
     case 4:
       return <>{label}</>;
   }

--- a/frontend/src/app/_components/add/spot/AddSpotImages.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotImages.tsx
@@ -1,13 +1,24 @@
 'use client';
 
+import { useContext } from 'react';
+import { SpotContext } from '@/context/travel/spot/SpotContext';
+
 import { InfoTitle } from '../common';
 import SpotImageHandler from '../../images/SpotImageHandler';
 
 export default function AddSpotImages() {
+  const [spot] = useContext(SpotContext);
+
   return (
     <section className="flex flex-col justify-center grow">
       <InfoTitle label="사진" additionalLabel="을 업로드하세요." />
-      <SpotImageHandler />
+      <div className="px-6 py-10 flex justify-between items-center">
+        <span className="pr-8 text-lg text-gray-400 shrink-0">이름</span>
+        <span className="text-2xl font-medium">{spot.place.name}</span>
+      </div>
+      <div className="px-4">
+        <SpotImageHandler />
+      </div>
     </section>
   );
 }

--- a/frontend/src/app/_components/add/spot/AddSpotImages.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotImages.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { InfoTitle } from '../common';
+import SpotImageHandler from '../../images/SpotImageHandler';
+
+export default function AddSpotImages() {
+  return (
+    <section className="flex flex-col justify-center grow">
+      <InfoTitle label="사진" additionalLabel="을 업로드하세요." />
+      <SpotImageHandler />
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/spot/AddSpotPlace.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotPlace.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useContext } from 'react';
+import { SpotContext } from '@/context/travel/spot/SpotContext';
+
+import type { TChoosePlace } from '@/context/travel/schema';
+
+const place: TChoosePlace = {
+  name: '선택한 장소',
+  address: '장소에 대한 도로명주소',
+  mapImageUrl: '장소 위치 지도 이미지',
+  coords: { lng: 35, lat: 125 },
+};
+
+export default function AddSpotPlace() {
+  const [, dispatch] = useContext(SpotContext);
+
+  return (
+    <section className="grow">
+      <button onClick={() => dispatch({ type: 'SET_PLACE', payload: place })}>
+        GOGOGO!!!
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/app/_components/add/spot/AddSpotReview.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotReview.tsx
@@ -16,9 +16,9 @@ export default function AddSpotReview() {
   return (
     <section className="flex flex-col justify-center grow">
       <InfoTitle label="리뷰" additionalLabel="를 남기세요." />
-      <div className="px-4 pb-4 flex justify-between items-center">
-        <span className="text-gray-400">이름</span>
-        <span className="text-xl">{state.place.name}</span>
+      <div className="px-6 py-10 flex justify-between items-center">
+        <span className="pr-8 text-lg text-gray-400 shrink-0">이름</span>
+        <span className="text-2xl font-medium">{state.place.name}</span>
       </div>
       <PostReview review={state.review} setReview={setReview} />
     </section>

--- a/frontend/src/app/_components/add/spot/AddSpotReview.tsx
+++ b/frontend/src/app/_components/add/spot/AddSpotReview.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useContext } from 'react';
+import { SpotContext } from '@/context/travel/spot/SpotContext';
+import { InfoTitle, PostReview } from '../common';
+
+import type { TReview } from '@/context/travel/schema';
+
+export default function AddSpotReview() {
+  const [state, dispatch] = useContext(SpotContext);
+
+  function setReview(nextReview: TReview) {
+    dispatch({ type: 'SET_REVIEW', payload: nextReview });
+  }
+
+  return (
+    <section className="flex flex-col justify-center grow">
+      <InfoTitle label="리뷰" additionalLabel="를 남기세요." />
+      <div className="px-4 pb-4 flex justify-between items-center">
+        <span className="text-gray-400">이름</span>
+        <span className="text-xl">{state.place.name}</span>
+      </div>
+      <PostReview review={state.review} setReview={setReview} />
+    </section>
+  );
+}

--- a/frontend/src/app/_components/images/CourseImageHandler.tsx
+++ b/frontend/src/app/_components/images/CourseImageHandler.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useContext } from 'react';
+
+import ImageHandler from '.';
+
+import type { TImageData } from './ImageHandler';
+import { CourseContext } from '@/context/travel/course/CourseContext';
+
+export default function CourseImageHandler({ order }: { order: number }) {
+  const [state, dispatch] = useContext(CourseContext);
+
+  function setImages(nextImages: TImageData[]) {
+    dispatch({
+      type: 'SET_SPOT_IMAGES',
+      payload: { data: nextImages, index: order },
+    });
+  }
+
+  return (
+    <ImageHandler images={state.spots[order].images} setImages={setImages} />
+  );
+}

--- a/frontend/src/app/_components/images/ImageHandler.tsx
+++ b/frontend/src/app/_components/images/ImageHandler.tsx
@@ -1,16 +1,9 @@
 'use client';
 
-import { useContext } from 'react';
-
+import { useState } from 'react';
 import ImageInput from './ImageInput';
 import ImagesContainer from './ImagesContainer';
-import { AddSpotContext } from '../add/spot/SpotContext';
-
-import type { Dispatch } from 'react';
-
-import type { TAddSpotAction } from '../add/spot/SpotContext';
-import { SpotContext } from '@/context/travel/spot/SpotContext';
-import { CourseContext } from '@/context/travel/course/CourseContext';
+import ToastMsg from '../ui/toast/ToastMsg';
 
 export interface TImageData {
   filename: string;
@@ -26,6 +19,8 @@ export default function ImageHandler({
   setImages: (newImages: TImageData[]) => void;
   size?: number;
 }) {
+  const [error, setError] = useState('');
+
   const availableSpace = size - images.length;
 
   const blankSpaces = [...Array(availableSpace)];
@@ -36,6 +31,7 @@ export default function ImageHandler({
         availableSpace={availableSpace}
         images={images}
         setImages={setImages}
+        invokeError={(title: string) => setError(title)}
       />
       <ImagesContainer images={images} setImages={setImages} />
       {blankSpaces.map((_, i) => (
@@ -44,6 +40,8 @@ export default function ImageHandler({
           className="aspect-square border-2 rounded-2xl border-gray-200 shrink-0"
         />
       ))}
+      {/* 에러 토스트 */}
+      {error !== '' && <ToastMsg key={Date.now()} title={error} timer={2000} />}
     </section>
   );
 }

--- a/frontend/src/app/_components/images/ImageHandler.tsx
+++ b/frontend/src/app/_components/images/ImageHandler.tsx
@@ -9,6 +9,8 @@ import { AddSpotContext } from '../add/spot/SpotContext';
 import type { Dispatch } from 'react';
 
 import type { TAddSpotAction } from '../add/spot/SpotContext';
+import { SpotContext } from '@/context/travel/spot/SpotContext';
+import { CourseContext } from '@/context/travel/course/CourseContext';
 
 export interface TImageData {
   filename: string;
@@ -16,39 +18,26 @@ export interface TImageData {
 }
 
 export default function ImageHandler({
-  dispatch,
-  size,
+  images,
+  setImages,
+  size = 5,
 }: {
-  dispatch: Dispatch<TAddSpotAction>;
-  size: number;
+  images: TImageData[];
+  setImages: (newImages: TImageData[]) => void;
+  size?: number;
 }) {
-  const addSpotState = useContext(AddSpotContext);
-  const images = addSpotState.images;
-
-  function addImages(newImages: TImageData[]) {
-    if (newImages.length === 0) {
-      return;
-    }
-
-    const currentImageNames = images.map((image) => image.filename);
-
-    const deduplicated = newImages.filter(
-      (image) => !currentImageNames.includes(image.filename),
-    );
-
-    const nextImages = [...images, ...deduplicated];
-
-    dispatch({ type: 'SET_IMAGES', payload: nextImages });
-  }
-
   const availableSpace = size - images.length;
 
   const blankSpaces = [...Array(availableSpace)];
 
   return (
     <section className="grid grid-rows-2 grid-cols-3 gap-2">
-      <ImageInput availableSpace={availableSpace} addImages={addImages} />
-      <ImagesContainer dispatch={dispatch} />
+      <ImageInput
+        availableSpace={availableSpace}
+        images={images}
+        setImages={setImages}
+      />
+      <ImagesContainer images={images} setImages={setImages} />
       {blankSpaces.map((_, i) => (
         <div
           key={i}

--- a/frontend/src/app/_components/images/ImageHandler.tsx
+++ b/frontend/src/app/_components/images/ImageHandler.tsx
@@ -41,7 +41,16 @@ export default function ImageHandler({
         />
       ))}
       {/* 에러 토스트 */}
-      {error !== '' && <ToastMsg key={Date.now()} title={error} timer={2000} />}
+      {error && (
+        <div className="absolute">
+          <ToastMsg
+            id={Date.now()}
+            key={Date.now()}
+            title={error}
+            timer={1000}
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/app/_components/images/ImageInput.tsx
+++ b/frontend/src/app/_components/images/ImageInput.tsx
@@ -7,6 +7,7 @@ import { blobTodataUrl } from '@/utils';
 import type { TImageData } from './ImageHandler';
 
 import ImageIcon from '/public/icons/image.svg';
+import { EventFor } from '@/types/type';
 
 export default function ImageInput({
   availableSpace,
@@ -22,6 +23,10 @@ export default function ImageInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function handleUpload(fileList: FileList) {
+    // if (availableSpace === 0) {
+    //   throw Error('더 이상 추가할 수 없습니다!');
+    // }
+
     if (fileList.length > availableSpace) {
       throw Error(`${availableSpace}개 이상 추가할 수 없습니다!`);
     }
@@ -42,6 +47,15 @@ export default function ImageInput({
     const nextImages = [...images, ...deduplicated];
 
     setImages(nextImages);
+  }
+
+  function handleClick(event: EventFor<'input', 'onClick'>) {
+    if (availableSpace === 0) {
+      event.preventDefault();
+      invokeError('더 이상 추가할 수 없습니다!');
+    }
+
+    setTimeout(() => invokeError(''), 1000);
   }
 
   return (
@@ -66,16 +80,7 @@ export default function ImageInput({
         type="file"
         accept="image/*"
         multiple
-        onClick={(e) => {
-          invokeError('');
-
-          if (availableSpace === 0) {
-            e.preventDefault();
-            // 토스트 호출
-            invokeError('더 이상 추가할 수 없습니다!');
-            return;
-          }
-        }}
+        onClick={handleClick}
         onInput={async (event) => {
           invokeError('');
 

--- a/frontend/src/app/_components/images/ImageInput.tsx
+++ b/frontend/src/app/_components/images/ImageInput.tsx
@@ -18,10 +18,12 @@ function toBase64(file: File) {
 
 export default function ImageInput({
   availableSpace,
-  addImages,
+  images,
+  setImages,
 }: {
   availableSpace: number;
-  addImages: (newImages: TImageData[]) => void;
+  images: TImageData[];
+  setImages: (newImages: TImageData[]) => void;
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -35,14 +37,22 @@ export default function ImageInput({
         throw Error(`${availableSpace}개 이상 추가할 수 없습니다!`);
       }
 
-      const images: TImageData[] = [];
+      const newImages: TImageData[] = [];
 
       for (let i = 0; i < fileList.length; i++) {
         const uri = await toBase64(fileList[i]);
-        images.push({ filename: fileList[i].name, uri });
+        newImages.push({ filename: fileList[i].name, uri });
       }
 
-      addImages(images);
+      const currentImageNames = images.map((image) => image.filename);
+
+      const deduplicated = newImages.filter(
+        (image) => !currentImageNames.includes(image.filename),
+      );
+
+      const nextImages = [...images, ...deduplicated];
+
+      setImages(nextImages);
     } catch (error) {
       alert(error);
     }

--- a/frontend/src/app/_components/images/ImagesContainer.tsx
+++ b/frontend/src/app/_components/images/ImagesContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   closestCenter,
   DndContext,
@@ -19,9 +19,7 @@ import {
 
 import ImageItem from './ImageItem';
 import SortableItem from './SortableItem';
-import { AddSpotContext } from '../add/spot/SpotContext';
 
-import type { Dispatch } from 'react';
 import type {
   DragEndEvent,
   DragStartEvent,
@@ -29,15 +27,14 @@ import type {
 } from '@dnd-kit/core';
 
 import type { TImageData } from './ImageHandler';
-import type { TAddSpotAction } from '../add/spot/SpotContext';
 
 export default function ImagesContainer({
-  dispatch,
+  images,
+  setImages,
 }: {
-  dispatch: Dispatch<TAddSpotAction>;
+  images: TImageData[];
+  setImages: (newImages: TImageData[]) => void;
 }) {
-  const { images } = useContext(AddSpotContext);
-
   const [activeId, setActiveId] = useState<string | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 0.01 } }),
@@ -75,18 +72,18 @@ export default function ImagesContainer({
       if (active.id !== over?.id) {
         const nextImage = imageMove(images, active.id, over?.id);
 
-        dispatch({ type: 'SET_IMAGES', payload: nextImage });
+        setImages(nextImage);
 
         setActiveId(null);
       }
     },
-    [images, dispatch],
+    [images, setImages],
   );
 
   function removeImage(filename: string) {
     const nextImages = images.filter((image) => image.filename !== filename);
 
-    dispatch({ type: 'SET_IMAGES', payload: nextImages });
+    setImages(nextImages);
   }
 
   const handleDragCancel = useCallback(() => {

--- a/frontend/src/app/_components/images/SpotImageHandler.tsx
+++ b/frontend/src/app/_components/images/SpotImageHandler.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useContext } from 'react';
+import { SpotContext } from '@/context/travel/spot/SpotContext';
+
+import ImageHandler from '.';
+
+import type { TImageData } from './ImageHandler';
+
+export default function SpotImageHandler() {
+  const [state, dispatch] = useContext(SpotContext);
+
+  function setImages(nextImages: TImageData[]) {
+    dispatch({ type: 'SET_IMAGES', payload: nextImages });
+  }
+
+  return <ImageHandler images={state.images} setImages={setImages} />;
+}

--- a/frontend/src/context/travel/course/reducer.ts
+++ b/frontend/src/context/travel/course/reducer.ts
@@ -1,4 +1,5 @@
 import {
+  choosePlaceSchema,
   currentSpotImagesSchema,
   currentSpotPlaceSchema,
   currentSpotReviewSchema,
@@ -8,7 +9,7 @@ import {
 } from '../schema';
 import { isEqualSpot } from '../utils';
 
-import type { TCourseState } from '../schema';
+import type { TCourseState, TSpotState } from '../schema';
 
 export const initialCourseState: TCourseState = {
   review: { title: '', content: '', rate: 1 },
@@ -46,7 +47,7 @@ export default function reducer(
       return { ...state, spots: result.data };
     }
     case 'ADD_SPOT': {
-      const result = spotStateSchema.safeParse(action.payload);
+      const result = choosePlaceSchema.safeParse(action.payload);
 
       /**
        * @todo SET_ERROR for Toast
@@ -56,7 +57,16 @@ export default function reducer(
         return { ...state };
       }
 
-      return { ...state, spots: [...state.spots, result.data] };
+      const newSpot: TSpotState = {
+        place: result.data,
+        images: [],
+        review: {
+          rate: 1,
+          content: '',
+        },
+      };
+
+      return { ...state, spots: [...state.spots, newSpot] };
     }
     case 'REMOVE_SPOT': {
       const result = spotStateSchema.safeParse(action.payload);

--- a/frontend/src/context/travel/schema.ts
+++ b/frontend/src/context/travel/schema.ts
@@ -4,7 +4,7 @@ import { inputImageSchema } from '@/app/_components/images';
 
 const IMAGES_COUNT = 5;
 const PLACES_COUNT = 5;
-const SPOTS_COUNT = 5;
+export const SPOTS_COUNT = 5;
 
 export const coordsSchema = z.object({ lng: z.number(), lat: z.number() });
 export type TCoords = z.infer<typeof coordsSchema>;


### PR DESCRIPTION
## Motivation 🧐
#499 에 이어, #483 에 대한 리팩토링 및 기능을 추가하였습니다.

## Key Changes 🔑
- Spot을 추가하는 플로우 중 사진/리뷰 입력 및 기록 확정 화면을 재구현하였습니다.
- Course를 추가하는 플로우 중 사진/리뷰 입력 및 기록 확정 화면을 구현하였습니다.

## To Reviewers 🙏
- 기존에 동작하던 추가 로직이 동작하지 않습니다. `/test/{spot|course}` 링크에서 기능을 사용해볼 수 있습니다. `place` 추가 로직을 작성하지 않은 상태이기 때문에 임시로 place를 넣어주는 버튼을 넣어두었습니다. 임시이기 떄문에 넣을 수 있는 place 개수에 별도 제한은 두지 않았습니다.
- 해당 브랜치에 여러 PR을 제출할 예정이며 모든 작업이 끝나면 develop으로 병합할 예정입니다.