### PR TITLE
DOM 구조 수정 및 맵 여는 버튼 클릭 시 상단으로 스크롤되도록 구현

### DIFF
--- a/frontend/src/app/_components/add/course/AddCourseConfirm.tsx
+++ b/frontend/src/app/_components/add/course/AddCourseConfirm.tsx
@@ -20,6 +20,7 @@ export default function AddCourseConfirm() {
 
   function open() {
     setIsMapOpen(true);
+    window.scrollTo({ top: 0 });
   }
 
   function close() {
@@ -31,8 +32,8 @@ export default function AddCourseConfirm() {
   const currentDate = new Date(Date.now());
 
   return (
-    <>
-      <section className="px-4 flex flex-col grow">
+    <section className="relative flex flex-col grow">
+      <div className="px-4 flex flex-col grow">
         <div className="px-2 py-4 flex justify-between">
           <span className="text-2xl font-semibold">{review.title}</span>
           <span className="flex items-center">
@@ -68,8 +69,8 @@ export default function AddCourseConfirm() {
             {review.content}
           </div>
         </div>
-      </section>
+      </div>
       {isMapOpen && <AddCourseConfirmMap close={close} />}
-    </>
+    </section>
   );
 }


### PR DESCRIPTION
## Motivation 🧐
일정 확인 화면에서 아래로 스크롤되어있을 때 상세 경로를 확인하기 위해 지도를 열면 X 버튼을 확인할 수 없는 오류를 수정합니다.

## Key Changes 🔑
- DOM 구조를 수정하여 `800px`(Galaxy S20)까지는 모든 화면이 보이는 것을 (반응형 디자인 모드로) 확인했습니다.
- 지도를 여는 버튼에 `scrollTo` 함수를 적용하여 위로 스크롤하도록 수정하였습니다.

## To Reviewers 🙏
