### PR TITLE
장소 대표 이미지에 지도 이미지가 입력되는 현상 수정

### DIFF
--- a/frontend/src/app/_components/add/AddTravelPlaceInfo.tsx
+++ b/frontend/src/app/_components/add/AddTravelPlaceInfo.tsx
@@ -21,7 +21,7 @@ export default function AddTravelPlaceInfo({
       </div>
       <div className="px-4 flex justify-between items-center">
         <span className="pr-8 text-lg text-gray-400 shrink-0">주소</span>
-        <span className="text-xl font-medium text-end">
+        <span className="text-xl font-medium text-end break-keep">
           {address.replace('&amp;', '&')}
         </span>
       </div>

--- a/frontend/src/app/_components/add/course/action.ts
+++ b/frontend/src/app/_components/add/course/action.ts
@@ -399,7 +399,7 @@ async function parseAddCourseState(course: TCourseState): Promise<FormData> {
       );
       formData.append(
         `spotRegisterRequests[${index}].placeImageFile`,
-        staticMapFile,
+        spotImages[index][0],
       );
     }
   });

--- a/frontend/src/app/_components/naver-map/markers/basicMarker.ts
+++ b/frontend/src/app/_components/naver-map/markers/basicMarker.ts
@@ -7,7 +7,7 @@ export const basicMarker = (
       selected ? '#3B82F6' : '#FFFFFF'
     }; border: 1px #3B82F6 solid; border-radius: 5px;">
       <div style="padding: 8px;">
-        <div style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; word-break: keep-all; color: ${
+        <div style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; color: ${
           selected ? '#FFFFFF' : '#374151'
         }; overflow: hidden; text-overflow: ellipsis; font-size: 18px; font-weight: 600; text-align: center;">${name}</div>
         </div>

--- a/frontend/src/app/_components/naver-map/markers/plusMarker.ts
+++ b/frontend/src/app/_components/naver-map/markers/plusMarker.ts
@@ -3,7 +3,7 @@ export const plusMarker = (name: string) => {
     content: `<div style="transform: translate(-50%, -100%); background-color: #3B82F6; border: 1px #3B82F6 solid; border-radius: 5px;">
       <div style="display: flex; padding: 8px">
         <div style="max-width: 215px; padding:0px 8px 0px 0px; color: #FFFFFF; font-size: 18px; font-weight: 600; text-align: center;">
-          <div style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; word-break: keep-all; overflow: hidden; text-overflow: ellipsis;">
+          <div style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow: hidden; text-overflow: ellipsis;">
             ${name}
           </div>
         </div>


### PR DESCRIPTION
## Motivation 🧐
장소 대표 이미지에 지도 이미지가 입력되던 오류가 있었습니다.

추가로, 지도에서 장소 선택 시 매우 긴 장소 이름에 말줄임표가 적용되지 않던 오류가 있었습니다.

중간에 공백이 없는 매우 긴 문자열을 처리하기 위해서는 컨테이너의 최대 길이가 명시되어야 하며, `word-break: keep-all`이 적용되면 안됩니다. 명시된 컨테이너의 최대 길이보다는 작지만 공백이 있어 wrap되는 문자열을 처리하기 위한 방법인 `word-break: keep-all`과 상충되기 때문에 해당 속성을 제거합니다.

## Key Changes 🔑
- 장소 대표 이미지에 지도 이미지가 입력되는 오류가 수정됩니다.
- 지도에서 장소 선택 시 매우 긴 장소 이름에 말줄임표가 적용되지 않던 오류가 수정됩니다.
- 장소 확인 화면의 주소에 대해 `word-break: keep-all`이 적용되었습니다.

## To Reviewers 🙏
