### PR TITLE
613 관리자 페이지 장소 관리를 위한 api 작성

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/favor/domain/Favor.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/favor/domain/Favor.java
@@ -25,7 +25,7 @@ public class Favor {
     private Member member;
 
     @ManyToOne
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "travel_id")
     private Travel travel;
 
     public Favor(final Member member, final Travel travel) {

--- a/backend/support/domain/src/main/java/kr/co/yigil/place/infrastructure/PlaceRepository.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/place/infrastructure/PlaceRepository.java
@@ -20,6 +20,9 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query(value = "SELECT p.* FROM Place p WHERE ST_Within(p.location, ST_MakeEnvelope(:minX, :minY, :maxX, :maxY, 4326))", nativeQuery = true)
     Page<Place> findWithinCoordinates(double minX, double minY, double maxX, double maxY, Pageable pageable);
 
+    @Query(value = "SELECT p.* FROM Place p WHERE ST_Within(p.location, ST_MakeEnvelope(:minX, :minY, :maxX, :maxY, 4326))", nativeQuery = true)
+    List<Place> findWithinCoordinates(double minX, double minY, double maxX, double maxY);
+
     @Query("SELECT p FROM Place p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(p.address) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Slice<Place> findByNameOrAddressContainingIgnoreCase(String keyword, Pageable pageable);
     }

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/application/PlaceFacade.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/application/PlaceFacade.java
@@ -1,7 +1,10 @@
 package kr.co.yigil.place.application;
 
+import java.util.List;
 import kr.co.yigil.place.domain.Place;
 import kr.co.yigil.place.domain.PlaceCommand;
+import kr.co.yigil.place.domain.PlaceInfo;
+import kr.co.yigil.place.domain.PlaceInfo.Map;
 import kr.co.yigil.place.domain.PlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -11,8 +14,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaceFacade {
     private final PlaceService placeService;
-    public Page<Place> getPlaces(PageRequest pageRequest) {
-        return placeService.getPlaces(pageRequest);
+
+    public List<Map> getPlaces(PlaceCommand.PlaceMapCommand command) {
+        return placeService.getPlaces(command);
     }
 
     public Place getPlaceDetail(Long placeId) {

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceCommand.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceCommand.java
@@ -1,13 +1,30 @@
 package kr.co.yigil.place.domain;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 public class PlaceCommand {
 
+    @Getter
+    public static class PlaceMapCommand {
+        private final double startX;
+        private final double startY;
+        private final double endX;
+        private final double endY;
+
+        public PlaceMapCommand(double x1, double y1, double x2, double y2) {
+            this.startX = x1;
+            this.startY = y1;
+            this.endX = x2;
+            this.endY = y2;
+        }
+    }
+
     @Data
     public static class UpdateImageCommand {
-        private Long placeId;
-        private MultipartFile imageFile;
+        private final Long placeId;
+        private final MultipartFile imageFile;
     }
 }

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceInfo.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceInfo.java
@@ -1,0 +1,25 @@
+package kr.co.yigil.place.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+public class PlaceInfo {
+
+    @Getter
+    @ToString
+    public static class Map {
+        private final Long id;
+        private final String name;
+        private final double x;
+        private final double y;
+
+        public Map(Place place) {
+            id = place.getId();
+            name = place.getName();
+            x = place.getLocation().getX();
+            y = place.getLocation().getY();
+        }
+    }
+
+
+}

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceReader.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceReader.java
@@ -1,11 +1,12 @@
 package kr.co.yigil.place.domain;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PlaceReader {
 
-    Page<Place> getPlaces(Pageable pageRequest);
+    List<Place> getPlaces(double startX, double startY, double endX, double endY);
 
     Place getPlace(Long placeId);
 }

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceService.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceService.java
@@ -1,11 +1,13 @@
 package kr.co.yigil.place.domain;
 
+import java.util.List;
+import kr.co.yigil.place.domain.PlaceInfo.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PlaceService {
 
-    Page<Place> getPlaces(Pageable pageRequest);
+    List<Map> getPlaces(PlaceCommand.PlaceMapCommand command);
 
     Place getPlaceDetail(Long placeId);
 

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceServiceImpl.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/domain/PlaceServiceImpl.java
@@ -1,7 +1,11 @@
 package kr.co.yigil.place.domain;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import kr.co.yigil.file.AttachFile;
 import kr.co.yigil.file.domain.FileUploader;
+import kr.co.yigil.place.domain.PlaceCommand.PlaceMapCommand;
+import kr.co.yigil.place.domain.PlaceInfo.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,9 +19,9 @@ public class PlaceServiceImpl implements PlaceService {
     private final PlaceReader placeReader;
 
     @Override
-    @Transactional(readOnly = true)
-    public Page<Place> getPlaces(Pageable pageRequest) {
-        return placeReader.getPlaces(pageRequest);
+    public List<PlaceInfo.Map> getPlaces(PlaceMapCommand command) {
+        var places = placeReader.getPlaces(command.getStartX(), command.getStartY(), command.getEndX(), command.getEndY());
+        return places.stream().map(Map::new).collect(Collectors.toList());
     }
 
     @Override

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/infrastructure/PlaceReaderImpl.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/infrastructure/PlaceReaderImpl.java
@@ -2,6 +2,7 @@ package kr.co.yigil.place.infrastructure;
 
 import static kr.co.yigil.global.exception.ExceptionCode.NOT_FOUND_PLACE_ID;
 
+import java.util.List;
 import kr.co.yigil.global.exception.BadRequestException;
 import kr.co.yigil.place.domain.Place;
 import kr.co.yigil.place.domain.PlaceReader;
@@ -16,8 +17,8 @@ public class PlaceReaderImpl implements PlaceReader {
     private final PlaceRepository placeRepository;
 
     @Override
-    public Page<Place> getPlaces(Pageable pageRequest) {
-        return placeRepository.findAll(pageRequest);
+    public List<Place> getPlaces(double startX, double startY, double endX, double endY) {
+        return placeRepository.findWithinCoordinates(startX, startY, endX, endY);
     }
 
     @Override

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/interfaces/controller/PlaceApiController.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/interfaces/controller/PlaceApiController.java
@@ -6,10 +6,12 @@ import kr.co.yigil.global.SortOrder;
 import kr.co.yigil.place.application.PlaceFacade;
 import kr.co.yigil.place.domain.Place;
 import kr.co.yigil.place.domain.PlaceCommand;
+import kr.co.yigil.place.domain.PlaceCommand.PlaceMapCommand;
 import kr.co.yigil.place.interfaces.dto.mapper.PlaceMapper;
 import kr.co.yigil.place.interfaces.dto.request.PlaceImageUpdateRequest;
 import kr.co.yigil.place.interfaces.dto.response.PlaceDetailResponse;
 import kr.co.yigil.place.interfaces.dto.response.PlaceImageUpdateResponse;
+import kr.co.yigil.place.interfaces.dto.response.PlaceMapResponse;
 import kr.co.yigil.place.interfaces.dto.response.PlacesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -28,16 +30,13 @@ public class PlaceApiController {
     private final PlaceMapper placeMapper;
 
     @GetMapping
-    public ResponseEntity<PlacesResponse> getPlaces(
-            @PageableDefault(size = 5, page = 1) Pageable pageable,
-            @RequestParam(name = "sortBy", defaultValue = "latest_uploaded_time", required = false) SortBy sortBy,
-            @RequestParam(name = "sortOrder", defaultValue = "desc", required = false) SortOrder sortOrder
+    public ResponseEntity<PlaceMapResponse> getPlaces(
+            @RequestParam(name = "startX") double startX,
+            @RequestParam(name = "startY") double startY,
+            @RequestParam(name = "endX") double endX,
+            @RequestParam(name = "endY") double endY
     ) {
-        Sort.Direction direction = Sort.Direction.fromString(sortOrder.getValue().toUpperCase());
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1,
-                pageable.getPageSize(),
-                Sort.by(direction, sortBy.getValue()));
-        var places = placeFacade.getPlaces(pageRequest);
+        var places = placeFacade.getPlaces(new PlaceMapCommand(startX, startY, endX, endY));
         var response = placeMapper.toResponse(places);
         return ResponseEntity.ok().body(response);
     }

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/interfaces/dto/mapper/PlaceMapper.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/interfaces/dto/mapper/PlaceMapper.java
@@ -1,9 +1,13 @@
 package kr.co.yigil.place.interfaces.dto.mapper;
 
+import java.util.List;
 import kr.co.yigil.place.domain.Place;
 import kr.co.yigil.place.domain.PlaceCommand;
+import kr.co.yigil.place.domain.PlaceInfo;
+import kr.co.yigil.place.domain.PlaceInfo.Map;
 import kr.co.yigil.place.interfaces.dto.request.PlaceImageUpdateRequest;
 import kr.co.yigil.place.interfaces.dto.response.PlaceDetailResponse;
+import kr.co.yigil.place.interfaces.dto.response.PlaceMapResponse;
 import kr.co.yigil.place.interfaces.dto.response.PlacesResponse;
 import kr.co.yigil.place.interfaces.dto.response.PointDto;
 import org.locationtech.jts.geom.Point;
@@ -19,12 +23,18 @@ import org.springframework.data.domain.Page;
 )
 public interface PlaceMapper {
 
-    default PlacesResponse toResponse(Page<Place> places) {
-        return new PlacesResponse(places.map(this::toDto));
-    }
+//    default PlacesResponse toResponse(Page<Place> places) {
+//        return new PlacesResponse(places.map(this::toDto));
+//    }
 
     @Mapping(target = "location", source = "location")
     PlacesResponse.PlaceInfoDto toDto(Place place);
+
+    default PlaceMapResponse toResponse(List<Map> places) {
+        return new PlaceMapResponse(places.stream().map(this::toDto).toList());
+    }
+
+    PlaceMapResponse.PlaceMapDto toDto(PlaceInfo.Map map);
 
     default PointDto map(Point value){
         return new PointDto(value.getX(), value.getY());

--- a/backend/yigil-admin/src/main/java/kr/co/yigil/place/interfaces/dto/response/PlaceMapResponse.java
+++ b/backend/yigil-admin/src/main/java/kr/co/yigil/place/interfaces/dto/response/PlaceMapResponse.java
@@ -4,20 +4,18 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class PlacesResponse {
-    private List<PlaceInfoDto> places;
+public class PlaceMapResponse {
+    private List<PlaceMapDto> places;
 
     @Data
-    public static class PlaceInfoDto {
+    public static class PlaceMapDto {
         private Long id;
         private String name;
-        private PointDto location;
+        private double x;
+        private double y;
     }
-
-
 }

--- a/backend/yigil-admin/src/test/java/kr/co/yigil/place/application/PlaceFacadeTest.java
+++ b/backend/yigil-admin/src/test/java/kr/co/yigil/place/application/PlaceFacadeTest.java
@@ -1,8 +1,11 @@
 package kr.co.yigil.place.application;
 
+import java.util.List;
 import kr.co.yigil.place.domain.Place;
 import kr.co.yigil.place.domain.PlaceCommand;
+import kr.co.yigil.place.domain.PlaceInfo.Map;
 import kr.co.yigil.place.domain.PlaceService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,15 +29,15 @@ class PlaceFacadeTest {
     private PlaceFacade placeFacade;
 
 
+    @DisplayName("getPlaces 메서드가 잘 동작하는지")
     @Test
     void getPlaces() {
-        Page<Place> mockPage = mock(Page.class);
-        when(placeService.getPlaces(any(PageRequest.class))).thenReturn(mockPage);
+        Map mockMap = mock(Map.class);
+        when(placeService.getPlaces(any(PlaceCommand.PlaceMapCommand.class))).thenReturn(List.of(mockMap));
 
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<Place> result = placeFacade.getPlaces(pageRequest);
+        List<Map> result = placeFacade.getPlaces(new PlaceCommand.PlaceMapCommand(1, 1, 1, 1));
 
-        assertEquals(mockPage, result);
+        assertEquals(List.of(mockMap), result);
     }
 
     @Test
@@ -49,7 +52,7 @@ class PlaceFacadeTest {
 
     @Test
     void updateImage() {
-        PlaceCommand.UpdateImageCommand command = new PlaceCommand.UpdateImageCommand();
+        PlaceCommand.UpdateImageCommand command = mock(PlaceCommand.UpdateImageCommand.class);
 
         placeFacade.updateImage(command);
 

--- a/backend/yigil-admin/src/test/java/kr/co/yigil/place/domain/PlaceServiceImplTest.java
+++ b/backend/yigil-admin/src/test/java/kr/co/yigil/place/domain/PlaceServiceImplTest.java
@@ -1,10 +1,14 @@
 package kr.co.yigil.place.domain;
 
+import java.time.LocalDateTime;
 import kr.co.yigil.file.AttachFile;
 import kr.co.yigil.file.domain.FileUploader;
+import kr.co.yigil.place.domain.PlaceCommand.PlaceMapCommand;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import org.springframework.security.core.parameters.P;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,14 +38,17 @@ class PlaceServiceImplTest {
 
     @DisplayName("장소 목록 조회")
     @Test
-    void whenGetPlaces_thenShouldReturnPlacePage() {
+    void whenGetPlaces_thenShouldReturnPlaceInfoList() {
 
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        when(placeReader.getPlaces(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(new Place())));
+        PlaceMapCommand command = new PlaceMapCommand(1, 1, 1, 1);
+        Point mockPoint = mock(Point.class);
+        AttachFile mockAttachFile = mock(AttachFile.class);
+        Place mockPlace = new Place(1L, "name", "address", mockPoint, mockAttachFile, mockAttachFile,
+                LocalDateTime.now());
+        when(placeReader.getPlaces(1, 1, 1, 1)).thenReturn(List.of(mockPlace));
 
-        var result = placeService.getPlaces(pageRequest);
-
-        assertThat(result).isNotNull().isInstanceOf(PageImpl.class);
+        var result = placeService.getPlaces(command);
+        verify(placeReader).getPlaces(1, 1, 1, 1);
     }
 
     @DisplayName("장소 상세 조회")
@@ -55,9 +63,7 @@ class PlaceServiceImplTest {
 
     @Test
     void updateImage() {
-        PlaceCommand.UpdateImageCommand command = new PlaceCommand.UpdateImageCommand();
-        command.setPlaceId(1L);
-        command.setImageFile(null);
+        PlaceCommand.UpdateImageCommand command = new PlaceCommand.UpdateImageCommand(1L, null);
 
         Place mockPlace = mock(Place.class);
         AttachFile mockAttachFile = mock(AttachFile.class);

--- a/backend/yigil-admin/src/test/java/kr/co/yigil/place/infrastructure/PlaceReaderImplTest.java
+++ b/backend/yigil-admin/src/test/java/kr/co/yigil/place/infrastructure/PlaceReaderImplTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,13 +34,12 @@ class PlaceReaderImplTest {
 
     @Test
     void getPlaces() {
-        Page<Place> page = new PageImpl<>(List.of(mock(Place.class)));
-        when(placeRepository.findAll(any(Pageable.class))).thenReturn(page);
+        Place place = mock(Place.class);
+        when(placeRepository.findWithinCoordinates(anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(List.of(place));
 
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<Place> result = placeReader.getPlaces(pageable);
+        List<Place> result = placeReader.getPlaces(1, 1, 1, 1);
 
-        assertEquals(page, result);
+        assertEquals(List.of(place), result);
     }
 
     @Test

--- a/backend/yigil-admin/src/test/java/kr/co/yigil/place/interfaces/controller/PlaceApiControllerTest.java
+++ b/backend/yigil-admin/src/test/java/kr/co/yigil/place/interfaces/controller/PlaceApiControllerTest.java
@@ -1,10 +1,15 @@
 package kr.co.yigil.place.interfaces.controller;
 
+import java.util.List;
 import kr.co.yigil.place.application.PlaceFacade;
 import kr.co.yigil.place.domain.Place;
 import kr.co.yigil.place.domain.PlaceCommand;
+import kr.co.yigil.place.domain.PlaceCommand.PlaceMapCommand;
+import kr.co.yigil.place.domain.PlaceInfo;
+import kr.co.yigil.place.domain.PlaceInfo.Map;
 import kr.co.yigil.place.interfaces.dto.mapper.PlaceMapper;
 import kr.co.yigil.place.interfaces.dto.response.PlaceDetailResponse;
+import kr.co.yigil.place.interfaces.dto.response.PlaceMapResponse;
 import kr.co.yigil.place.interfaces.dto.response.PlacesResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -41,14 +47,15 @@ class PlaceApiControllerTest {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
     }
 
-
-    @DisplayName("장소 리스트를 조회하는 테스트")
+    @DisplayName("getPlaces 메서드가 잘 동작하는지")
     @Test
-    void whenGetPlaces_thenShouldReturn200AndResponse() throws Exception {
-        when(placeFacade.getPlaces(any())).thenReturn(mock(Page.class));
-        when(placeMapper.toResponse(any(Page.class))).thenReturn(mock(PlacesResponse.class));
+    void getPlaces() throws Exception {
+        PlaceInfo.Map map = mock (PlaceInfo.Map.class);
 
-        mockMvc.perform(get("/api/v1/places"))
+        when(placeFacade.getPlaces(any(PlaceMapCommand.class))).thenReturn(List.of(map));
+        when(placeMapper.toResponse(List.of(map))).thenReturn(mock(PlaceMapResponse.class));
+
+        mockMvc.perform(get("/api/v1/places?startX=1&startY=1&endX=1&endY=1"))
             .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
## Motivation 🧐
- 관리자 페이지의 지도 뷰 구현을 위해 api를 추가합니다.
<br>

## Key Changes 🔑
- 기존의 지도뷰에 사용하던 쿼리를 재사용하여, 어드민 지도뷰에 맞게 페이지를 출력합니다 (차이는 페이징 여부 말곤 없습니다)
<br>

## To Reviewers 🙏
