### PR TITLE
616 spot 생성 요청 객체를 변경합니다

### DIFF
--- a/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/Spot.java
+++ b/backend/support/domain/src/main/java/kr/co/yigil/travel/domain/Spot.java
@@ -35,10 +35,9 @@ public class Spot extends Travel {
     @JoinColumn(name = "place_id")
     private Place place;
 
-    public Spot(final Long id, final Member member, final Point location, final boolean isInCourse,
-        final String title, final String description, final AttachFiles attachFiles,
+    public Spot(final Long id, final Member member, final Point location, final boolean isInCourse, final String description, final AttachFiles attachFiles,
         final Place place, final double rate) {
-        super(id, member, title, description, rate, false);
+        super(id, member, "", description, rate, false);
         this.location = location;
         this.isInCourse = isInCourse;
         this.attachFiles = attachFiles;
@@ -47,10 +46,10 @@ public class Spot extends Travel {
     }
 
 
-    public Spot(final Member member, final Point location, final boolean isInCourse, final String title,
+    public Spot(final Member member, final Point location, final boolean isInCourse,
             final String description, final AttachFiles attachFiles, final Place place,
             final double rate) {
-        super(member, title, description, rate, false);
+        super(member, "", description, rate, false);
         this.location = location;
         this.isInCourse = isInCourse;
         this.attachFiles = attachFiles;

--- a/backend/yigil-admin/src/test/java/kr/co/yigil/travel/spot/domain/SpotServiceImplTest.java
+++ b/backend/yigil-admin/src/test/java/kr/co/yigil/travel/spot/domain/SpotServiceImplTest.java
@@ -83,7 +83,7 @@ class SpotServiceImplTest {
                 mockAttachFile, LocalDateTime.now());
         AttachFiles attachFiles = new AttachFiles(List.of(mockAttachFile, mockAttachFile));
 
-        Spot spot = new Spot(1L, mock(Member.class), location, false, null, null, attachFiles,
+        Spot spot = new Spot(1L, mock(Member.class), location, false, null, attachFiles,
                 mockPlace, 5.0);
         when(spotReader.getSpot(spotId)).thenReturn(spot);
         when(location.getCoordinate()).thenReturn(new Coordinate(1.0, 1.0));

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotCommand.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotCommand.java
@@ -1,7 +1,5 @@
 package kr.co.yigil.travel.domain.spot;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import kr.co.yigil.file.AttachFile;
 import kr.co.yigil.file.AttachFiles;
 import kr.co.yigil.member.Member;
@@ -14,6 +12,9 @@ import lombok.Getter;
 import lombok.ToString;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class SpotCommand {
 
     @Getter
@@ -22,7 +23,6 @@ public class SpotCommand {
     public static class RegisterSpotRequest {
 
         private final String pointJson;
-        private final String title;
         private final String description;
         private final double rate;
         private final List<MultipartFile> files;
@@ -33,7 +33,6 @@ public class SpotCommand {
                     member,
                     GeojsonConverter.convertToPoint(pointJson),
                     isInCourse,
-                    title,
                     description,
                     attachFiles,
                     place,
@@ -48,7 +47,6 @@ public class SpotCommand {
     public static class RegisterPlaceRequest {
 
         private final MultipartFile mapStaticImageFile;
-        private final MultipartFile placeImageFile;
         private final String placeName;
         private final String placeAddress;
         private final String placePointJson;

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotServiceImpl.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/domain/spot/SpotServiceImpl.java
@@ -2,6 +2,7 @@ package kr.co.yigil.travel.domain.spot;
 
 import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.favor.domain.FavorReader;
+import kr.co.yigil.file.AttachFile;
 import kr.co.yigil.file.FileUploader;
 import kr.co.yigil.global.Selected;
 import kr.co.yigil.global.exception.AuthException;
@@ -78,8 +79,8 @@ public class SpotServiceImpl implements SpotService {
 			throw new BadRequestException(ExceptionCode.SPOT_ALREADY_EXIST_IN_PLACE);
 		}
 
-		Place place = optionalPlace.orElseGet(() -> registerNewPlace(command.getRegisterPlaceRequest()));
 		var attachFiles = spotSeriesFactory.initAttachFiles(command);
+		Place place = optionalPlace.orElseGet(() -> registerNewPlace(command.getRegisterPlaceRequest(), attachFiles.getFiles().getFirst()));
 		placeCacheStore.incrementSpotCountInPlace(place.getId());
 		placeCacheStore.incrementSpotTotalRateInPlace(place.getId(), command.getRate());
 		spotStore.store(command.toEntity(member, place, false, attachFiles));
@@ -113,8 +114,7 @@ public class SpotServiceImpl implements SpotService {
 		spotStore.remove(spot);
     }
 
-    private Place registerNewPlace(RegisterPlaceRequest command) {
-        var placeImageFile = fileUploader.upload(command.getPlaceImageFile());
+    private Place registerNewPlace(RegisterPlaceRequest command, AttachFile placeImageFile) {
         var mapStaticImage = fileUploader.upload(command.getMapStaticImageFile());
         return placeStore.store(command.toEntity(placeImageFile, mapStaticImage));
     }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/infrastructure/course/CourseSpotSeriesFactoryImpl.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/infrastructure/course/CourseSpotSeriesFactoryImpl.java
@@ -1,9 +1,6 @@
 package kr.co.yigil.travel.infrastructure.course;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import kr.co.yigil.file.AttachFile;
 import kr.co.yigil.file.AttachFiles;
 import kr.co.yigil.file.FileUploader;
 import kr.co.yigil.member.Member;
@@ -22,6 +19,11 @@ import kr.co.yigil.travel.domain.spot.SpotStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -45,11 +47,12 @@ public class CourseSpotSeriesFactoryImpl implements CourseSpotSeriesFactory {
                 .map(registerSpotRequest -> {
                     var registerPlaceRequest = registerSpotRequest.getRegisterPlaceRequest();
                     Optional<Place> optionalPlace = placeReader.findPlaceByNameAndAddress(registerPlaceRequest.getPlaceName(), registerPlaceRequest.getPlaceAddress());
-                    Place place = optionalPlace.orElseGet(() -> registerNewPlace(registerPlaceRequest));
 
                     var attachFiles = new AttachFiles(registerSpotRequest.getFiles().stream()
                             .map(fileUploader::upload)
                             .collect(Collectors.toList()));
+
+                    Place place = optionalPlace.orElseGet(() -> registerNewPlace(registerPlaceRequest, attachFiles.getFiles().getFirst()));
 
                     placeCacheStore.incrementSpotCountInPlace(place.getId());
                     placeCacheStore.incrementSpotTotalRateInPlace(place.getId(), registerSpotRequest.getRate());
@@ -66,8 +69,8 @@ public class CourseSpotSeriesFactoryImpl implements CourseSpotSeriesFactory {
         return spots;
     }
 
-    private Place registerNewPlace(RegisterPlaceRequest command) {
-        var placeImage = fileUploader.upload(command.getPlaceImageFile());
+    private Place registerNewPlace(RegisterPlaceRequest command, AttachFile placeImage) {
+
         var mapStaticImage = fileUploader.upload(command.getMapStaticImageFile());
         return placeStore.store(command.toEntity(placeImage, mapStaticImage));
     }

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/mapper/SpotMapper.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/mapper/SpotMapper.java
@@ -1,10 +1,5 @@
 package kr.co.yigil.travel.interfaces.dto.mapper;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.stream.Collectors;
-import kr.co.yigil.travel.domain.Spot;
 import kr.co.yigil.travel.domain.spot.SpotCommand;
 import kr.co.yigil.travel.domain.spot.SpotInfo;
 import kr.co.yigil.travel.domain.spot.SpotInfo.Main;
@@ -21,7 +16,11 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
-import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface SpotMapper {
@@ -70,13 +69,11 @@ public interface SpotMapper {
 
     @Mappings({
         @Mapping(target = "registerPlaceRequest.mapStaticImageFile", source = "mapStaticImageFile"),
-        @Mapping(target = "registerPlaceRequest.placeImageFile", source = "placeImageFile"),
         @Mapping(target = "registerPlaceRequest.placeName", source = "placeName"),
         @Mapping(target = "registerPlaceRequest.placeAddress", source = "placeAddress"),
-        @Mapping(target = "registerPlaceRequest.placePointJson", source = "placePointJson"),
+        @Mapping(target = "registerPlaceRequest.placePointJson", source = "pointJson"),
         @Mapping(target = "files", source = "files"),
         @Mapping(target = "pointJson", source = "pointJson"),
-        @Mapping(target = "title", source = "title"),
         @Mapping(target = "description", source = "description"),
         @Mapping(target = "rate", source = "rate")
     })
@@ -85,10 +82,9 @@ public interface SpotMapper {
     default SpotCommand.RegisterPlaceRequest toRegisterPlaceRequest(SpotRegisterRequest request) {
         return SpotCommand.RegisterPlaceRequest.builder()
             .mapStaticImageFile(request.getMapStaticImageFile())
-            .placeImageFile(request.getPlaceImageFile())
             .placeName(request.getPlaceName())
             .placeAddress(request.getPlaceAddress())
-            .placePointJson(request.getPlacePointJson())
+            .placePointJson(request.getPointJson())
             .build();
     }
 

--- a/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/request/SpotRegisterRequest.java
+++ b/backend/yigil-api/src/main/java/kr/co/yigil/travel/interfaces/dto/request/SpotRegisterRequest.java
@@ -1,24 +1,22 @@
 package kr.co.yigil.travel.interfaces.dto.request;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class SpotRegisterRequest {
     private String pointJson;
-    private String title;
     private String description;
     private List<MultipartFile> files;
     private double rate;
 
     private MultipartFile mapStaticImageFile;
-    private MultipartFile placeImageFile;
     private String placeName;
     private String placeAddress;
-    private String placePointJson;
 }

--- a/backend/yigil-api/src/main/resources/static/docs/course-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/course-api.html
@@ -670,11 +670,6 @@ Content-Length: 306
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 포인트 정보</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 제목</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 본문</p></td>
@@ -693,11 +688,6 @@ Content-Length: 306
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].placeAddress</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 장소 주소</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].placePointJson</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 장소 포인트 정보</p></td>
 </tr>
 </tbody>
 </table>
@@ -730,10 +720,6 @@ Content-Length: 306
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[0].mapStaticImageFile</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 위치 정보를 나타내는 지도 이미지 파일</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[0].placeImageFile</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 장소 이미지 파일</p></td>
-</tr>
 </tbody>
 </table>
 </div>
@@ -743,7 +729,7 @@ Content-Length: 306
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/courses HTTP/1.1
 Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Length: 366
+Content-Length: 313
 Host: spring.restdocs.test
 
 {
@@ -755,12 +741,10 @@ Host: spring.restdocs.test
   "lineStringJson" : "test",
   "spotRegisterRequests" : [ {
     "pointJson" : "test",
-    "title" : "test",
     "description" : "test",
     "rate" : 4.5,
     "placeName" : "test",
-    "placeAddress" : "test",
-    "placePointJson" : "test"
+    "placeAddress" : "test"
   } ]
 }</code></pre>
 </div>
@@ -1094,7 +1078,7 @@ Content-Length: 481
   "rate" : 4.5,
   "map_static_image_url" : "images/static.png",
   "description" : "본문",
-  "created_date" : "2024-03-21T00:19:31.444626",
+  "created_date" : "2024-03-23T21:57:03.350748",
   "line_string_json" : "lineStringJson",
   "spots" : [ {
     "id" : 1,
@@ -1697,7 +1681,7 @@ Content-Length: 324
     "spot_count" : 3,
     "rate" : 4.5,
     "liked" : false,
-    "create_date" : "2024-03-21T00:19:31.314895"
+    "create_date" : "2024-03-23T21:57:03.248698"
   } ],
   "has_next" : false
 }</code></pre>
@@ -1845,7 +1829,7 @@ Host: spring.restdocs.test
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344648",
+    "create_date" : "2024-03-23T21:57:03.270153",
     "point" : {
       "x" : 1.0,
       "y" : 1.0
@@ -1857,7 +1841,7 @@ Host: spring.restdocs.test
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344964",
+    "create_date" : "2024-03-23T21:57:03.270429",
     "point" : {
       "x" : 2.0,
       "y" : 2.0
@@ -1883,7 +1867,7 @@ Content-Length: 665
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344648",
+    "create_date" : "2024-03-23T21:57:03.270153",
     "point" : {
       "x" : 1.0,
       "y" : 1.0
@@ -1895,7 +1879,7 @@ Content-Length: 665
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344964",
+    "create_date" : "2024-03-23T21:57:03.270429",
     "point" : {
       "x" : 2.0,
       "y" : 2.0

--- a/backend/yigil-api/src/main/resources/static/docs/index.html
+++ b/backend/yigil-api/src/main/resources/static/docs/index.html
@@ -889,11 +889,6 @@ Content-Length: 183
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 위치를 나타내는 geojson</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 제목</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 본문</p></td>
@@ -912,11 +907,6 @@ Content-Length: 183
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>placeAddress</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟 관련 장소 주소</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>placePointJson</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟 관련 장소의 위치를 나타내는 geojson</p></td>
 </tr>
 </tbody>
 </table>
@@ -943,11 +933,7 @@ Content-Length: 183
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>mapStaticImageFile</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spot의 장소를 나타내는 지도 이미지 파일(필수x)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>placeImageFile</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spot의 장소를 나타내는 썸네일 이미지 파일(필수x)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spot의 장소를 나타내는 지도 이미지 파일</p></td>
 </tr>
 </tbody>
 </table>
@@ -958,17 +944,15 @@ Content-Length: 183
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/spots HTTP/1.1
 Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Length: 330
+Content-Length: 217
 Host: spring.restdocs.test
 
 {
   "pointJson" : "{ \"type\" : \"Point\", \"coordinates\": [ 555,  555 ] }",
-  "title" : "스팟 타이틀",
   "description" : "스팟 본문",
   "rate" : 5.0,
   "placeName" : "장소 타이틀",
-  "placeAddress" : "장소구 장소면 장소리",
-  "placePointJson" : "{ \"type\" : \"Point\", \"coordinates\": [ 555,  555 ] }"
+  "placeAddress" : "장소구 장소면 장소리"
 }</code></pre>
 </div>
 </div>
@@ -1758,11 +1742,6 @@ Content-Length: 306
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 포인트 정보</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 제목</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 본문</p></td>
@@ -1781,11 +1760,6 @@ Content-Length: 306
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].placeAddress</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 장소 주소</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[].placePointJson</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 장소 포인트 정보</p></td>
 </tr>
 </tbody>
 </table>
@@ -1818,10 +1792,6 @@ Content-Length: 306
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[0].mapStaticImageFile</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 위치 정보를 나타내는 지도 이미지 파일</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotRegisterRequests[0].placeImageFile</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 장소 이미지 파일</p></td>
-</tr>
 </tbody>
 </table>
 </div>
@@ -1831,7 +1801,7 @@ Content-Length: 306
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/courses HTTP/1.1
 Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Length: 366
+Content-Length: 313
 Host: spring.restdocs.test
 
 {
@@ -1843,12 +1813,10 @@ Host: spring.restdocs.test
   "lineStringJson" : "test",
   "spotRegisterRequests" : [ {
     "pointJson" : "test",
-    "title" : "test",
     "description" : "test",
     "rate" : 4.5,
     "placeName" : "test",
-    "placeAddress" : "test",
-    "placePointJson" : "test"
+    "placeAddress" : "test"
   } ]
 }</code></pre>
 </div>
@@ -2182,7 +2150,7 @@ Content-Length: 481
   "rate" : 4.5,
   "map_static_image_url" : "images/static.png",
   "description" : "본문",
-  "created_date" : "2024-03-21T00:19:31.444626",
+  "created_date" : "2024-03-23T21:57:03.350748",
   "line_string_json" : "lineStringJson",
   "spots" : [ {
     "id" : 1,
@@ -2785,7 +2753,7 @@ Content-Length: 324
     "spot_count" : 3,
     "rate" : 4.5,
     "liked" : false,
-    "create_date" : "2024-03-21T00:19:31.314895"
+    "create_date" : "2024-03-23T21:57:03.248698"
   } ],
   "has_next" : false
 }</code></pre>
@@ -2933,7 +2901,7 @@ Host: spring.restdocs.test
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344648",
+    "create_date" : "2024-03-23T21:57:03.270153",
     "point" : {
       "x" : 1.0,
       "y" : 1.0
@@ -2945,7 +2913,7 @@ Host: spring.restdocs.test
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344964",
+    "create_date" : "2024-03-23T21:57:03.270429",
     "point" : {
       "x" : 2.0,
       "y" : 2.0
@@ -2971,7 +2939,7 @@ Content-Length: 665
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344648",
+    "create_date" : "2024-03-23T21:57:03.270153",
     "point" : {
       "x" : 1.0,
       "y" : 1.0
@@ -2983,7 +2951,7 @@ Content-Length: 665
     "rate" : 4.5,
     "description" : "스팟 본문",
     "image_urls" : [ "images/spot.jpg", "images/spotted.png" ],
-    "create_date" : "2024-03-21T00:19:31.344964",
+    "create_date" : "2024-03-23T21:57:03.270429",
     "point" : {
       "x" : 2.0,
       "y" : 2.0
@@ -7321,14 +7289,14 @@ Host: spring.restdocs.test
       "id" : 1,
       "name" : "광고성 글"
     },
-    "created_at" : "2024-03-21T00:19:30.287121"
+    "created_at" : "2024-03-23T21:57:02.120413"
   }, {
     "id" : 2,
     "report_type" : {
       "id" : 2,
       "name" : "욕설"
     },
-    "created_at" : "2024-03-21T00:19:30.287166"
+    "created_at" : "2024-03-23T21:57:02.120467"
   } ],
   "total_page" : 1
 }</code></pre>
@@ -7404,14 +7372,14 @@ Content-Length: 326
       "id" : 1,
       "name" : "광고성 글"
     },
-    "created_at" : "2024-03-21T00:19:30.287121"
+    "created_at" : "2024-03-23T21:57:02.120413"
   }, {
     "id" : 2,
     "report_type" : {
       "id" : 2,
       "name" : "욕설"
     },
-    "created_at" : "2024-03-21T00:19:30.287166"
+    "created_at" : "2024-03-23T21:57:02.120467"
   } ],
   "total_page" : 1
 }</code></pre>
@@ -7481,7 +7449,7 @@ Host: spring.restdocs.test</code></pre>
     "id" : 1,
     "name" : "광고성 글"
   },
-  "created_at" : "2024-03-21T00:19:30.298753"
+  "created_at" : "2024-03-23T21:57:02.130878"
 }</code></pre>
 </div>
 </div>
@@ -7544,7 +7512,7 @@ Content-Length: 129
     "id" : 1,
     "name" : "광고성 글"
   },
-  "created_at" : "2024-03-21T00:19:30.298753"
+  "created_at" : "2024-03-23T21:57:02.130878"
 }</code></pre>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/report-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/report-api.html
@@ -644,14 +644,14 @@ Host: spring.restdocs.test
       "id" : 1,
       "name" : "광고성 글"
     },
-    "created_at" : "2024-03-21T00:19:30.287121"
+    "created_at" : "2024-03-23T21:57:02.120413"
   }, {
     "id" : 2,
     "report_type" : {
       "id" : 2,
       "name" : "욕설"
     },
-    "created_at" : "2024-03-21T00:19:30.287166"
+    "created_at" : "2024-03-23T21:57:02.120467"
   } ],
   "total_page" : 1
 }</code></pre>
@@ -727,14 +727,14 @@ Content-Length: 326
       "id" : 1,
       "name" : "광고성 글"
     },
-    "created_at" : "2024-03-21T00:19:30.287121"
+    "created_at" : "2024-03-23T21:57:02.120413"
   }, {
     "id" : 2,
     "report_type" : {
       "id" : 2,
       "name" : "욕설"
     },
-    "created_at" : "2024-03-21T00:19:30.287166"
+    "created_at" : "2024-03-23T21:57:02.120467"
   } ],
   "total_page" : 1
 }</code></pre>
@@ -804,7 +804,7 @@ Host: spring.restdocs.test</code></pre>
     "id" : 1,
     "name" : "광고성 글"
   },
-  "created_at" : "2024-03-21T00:19:30.298753"
+  "created_at" : "2024-03-23T21:57:02.130878"
 }</code></pre>
 </div>
 </div>
@@ -867,7 +867,7 @@ Content-Length: 129
     "id" : 1,
     "name" : "광고성 글"
   },
-  "created_at" : "2024-03-21T00:19:30.298753"
+  "created_at" : "2024-03-23T21:57:02.130878"
 }</code></pre>
 </div>
 </div>

--- a/backend/yigil-api/src/main/resources/static/docs/spot-api.html
+++ b/backend/yigil-api/src/main/resources/static/docs/spot-api.html
@@ -748,11 +748,6 @@ Content-Length: 183
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 위치를 나타내는 geojson</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 제목</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟의 본문</p></td>
@@ -771,11 +766,6 @@ Content-Length: 183
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>placeAddress</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스팟 관련 장소 주소</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>placePointJson</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">스팟 관련 장소의 위치를 나타내는 geojson</p></td>
 </tr>
 </tbody>
 </table>
@@ -802,11 +792,7 @@ Content-Length: 183
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>mapStaticImageFile</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spot의 장소를 나타내는 지도 이미지 파일(필수x)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>placeImageFile</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spot의 장소를 나타내는 썸네일 이미지 파일(필수x)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spot의 장소를 나타내는 지도 이미지 파일</p></td>
 </tr>
 </tbody>
 </table>
@@ -817,17 +803,15 @@ Content-Length: 183
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/spots HTTP/1.1
 Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Length: 330
+Content-Length: 217
 Host: spring.restdocs.test
 
 {
   "pointJson" : "{ \"type\" : \"Point\", \"coordinates\": [ 555,  555 ] }",
-  "title" : "스팟 타이틀",
   "description" : "스팟 본문",
   "rate" : 5.0,
   "placeName" : "장소 타이틀",
-  "placeAddress" : "장소구 장소면 장소리",
-  "placePointJson" : "{ \"type\" : \"Point\", \"coordinates\": [ 555,  555 ] }"
+  "placeAddress" : "장소구 장소면 장소리"
 }</code></pre>
 </div>
 </div>

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/domain/spot/SpotServiceImplTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/domain/spot/SpotServiceImplTest.java
@@ -158,7 +158,7 @@ public class SpotServiceImplTest {
         Place place = new Place(placeId, placeName, placeAddress, null, null, null, null);
         Spot spot = mock(Spot.class);
         RegisterPlaceRequest placeCommand = mock(RegisterPlaceRequest.class);
-        AttachFiles mockAttachFiles = mock(AttachFiles.class);
+        AttachFiles mockAttachFiles = new AttachFiles(List.of(mock(AttachFile.class)));
 
         when(memberReader.getMember(memberId)).thenReturn(member);
         when(command.getRegisterPlaceRequest()).thenReturn(placeCommand);
@@ -172,7 +172,7 @@ public class SpotServiceImplTest {
 
         spotService.registerSpot(command, memberId);
 
-        verify(fileUploader, times(2)).upload(any());
+        verify(fileUploader, times(1)).upload(any());
         verify(placeStore).store(any());
         verify(spotStore).store(any(Spot.class));
     }

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/CourseApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/CourseApiControllerTest.java
@@ -145,17 +145,16 @@ public class CourseApiControllerTest {
 
         MockMultipartFile spotMapStaticImage = new MockMultipartFile("mapStatic", "mapStatic.png",
                 "image/png", "<<png data>>".getBytes());
-        MockMultipartFile placeImage = new MockMultipartFile("placeImg", "placeImg.png",
-                "image/png", "<<png data>>".getBytes());
+//        MockMultipartFile placeImage = new MockMultipartFile("placeImg", "placeImg.png",
+//                "image/png", "<<png data>>".getBytes());
 
-        String requestBody = "{\"title\" : \"test\", \"description\" : \"test\", \"rate\" : 4.5, \"isPrivate\" : false, \"representativeSpotOrder\" : 1, \"lineStringJson\" : \"test\", \"spotRegisterRequests\" : [{\"pointJson\" : \"test\", \"title\" : \"test\", \"description\" : \"test\", \"rate\" : 4.5, \"placeName\" : \"test\", \"placeAddress\" : \"test\", \"placePointJson\" : \"test\"}]}";
+        String requestBody = "{\"title\" : \"test\", \"description\" : \"test\", \"rate\" : 4.5, \"isPrivate\" : false, \"representativeSpotOrder\" : 1, \"lineStringJson\" : \"test\", \"spotRegisterRequests\" : [{\"pointJson\" : \"test\", \"description\" : \"test\", \"rate\" : 4.5, \"placeName\" : \"test\", \"placeAddress\" : \"test\"}]}";
 
         mockMvc.perform(multipart("/api/v1/courses")
                         .file("mapStaticImageFile", mapStaticImage.getBytes())
                         .file("spotRegisterRequests[0].files", image1.getBytes())
                         .file("spotRegisterRequests[0].files", image2.getBytes())
                         .file("spotRegisterRequests[0].mapStaticImageFile", spotMapStaticImage.getBytes())
-                        .file("spotRegisterRequests[0].placeImageFile", placeImage.getBytes())
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .content(requestBody))
                 .andExpect(status().isOk())
@@ -170,9 +169,7 @@ public class CourseApiControllerTest {
                                         "스팟 관련 이미지 파일"),
                                 partWithName(
                                         "spotRegisterRequests[0].mapStaticImageFile").description(
-                                        "스팟의 위치 정보를 나타내는 지도 이미지 파일"),
-                                partWithName("spotRegisterRequests[0].placeImageFile").description(
-                                        "스팟의 장소 이미지 파일")
+                                        "스팟의 위치 정보를 나타내는 지도 이미지 파일")
                         ),
                         requestFields(
                                 fieldWithPath("title").type(JsonFieldType.STRING)
@@ -191,8 +188,6 @@ public class CourseApiControllerTest {
                                         "코스 내 스팟의 정보"),
                                 fieldWithPath("spotRegisterRequests[].pointJson").type(
                                         JsonFieldType.STRING).description("스팟의 포인트 정보"),
-                                fieldWithPath("spotRegisterRequests[].title").type(
-                                        JsonFieldType.STRING).description("스팟의 제목"),
                                 fieldWithPath("spotRegisterRequests[].description").type(
                                         JsonFieldType.STRING).description("스팟의 본문"),
                                 fieldWithPath("spotRegisterRequests[].rate").type(
@@ -200,9 +195,7 @@ public class CourseApiControllerTest {
                                 fieldWithPath("spotRegisterRequests[].placeName").type(
                                         JsonFieldType.STRING).description("스팟의 장소명"),
                                 fieldWithPath("spotRegisterRequests[].placeAddress").type(
-                                        JsonFieldType.STRING).description("스팟의 장소 주소"),
-                                fieldWithPath("spotRegisterRequests[].placePointJson").type(
-                                        JsonFieldType.STRING).description("스팟의 장소 포인트 정보")
+                                        JsonFieldType.STRING).description("스팟의 장소 주소")
                         ),
                         responseFields(
                                 fieldWithPath("message").type(JsonFieldType.STRING)

--- a/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
+++ b/backend/yigil-api/src/test/java/kr/co/yigil/travel/interfaces/controller/SpotApiControllerTest.java
@@ -1,29 +1,5 @@
 package kr.co.yigil.travel.interfaces.controller;
 
-import static kr.co.yigil.RestDocumentUtils.getDocumentRequest;
-import static kr.co.yigil.RestDocumentUtils.getDocumentResponse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
 import kr.co.yigil.auth.domain.Accessor;
 import kr.co.yigil.global.Selected;
 import kr.co.yigil.travel.application.SpotFacade;
@@ -55,6 +31,20 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static kr.co.yigil.RestDocumentUtils.getDocumentRequest;
+import static kr.co.yigil.RestDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
 @WebMvcTest(SpotApiController.class)
@@ -175,14 +165,12 @@ class SpotApiControllerTest {
             "image/png", "<<png data>>".getBytes());
         MockMultipartFile placeImage = new MockMultipartFile("placeImg", "placeImg.png",
             "image/png", "<<png data>>".getBytes());
-
-        String requestBody = "{\"pointJson\": \"{ \\\"type\\\" : \\\"Point\\\", \\\"coordinates\\\": [ 555,  555 ] }\", \"title\": \"스팟 타이틀\", \"description\": \"스팟 본문\", \"rate\": 5.0, \"placeName\": \"장소 타이틀\", \"placeAddress\": \"장소구 장소면 장소리\", \"placePointJson\": \"{ \\\"type\\\" : \\\"Point\\\", \\\"coordinates\\\": [ 555,  555 ] }\"}";
+        String requestBody = "{\"pointJson\": \"{ \\\"type\\\" : \\\"Point\\\", \\\"coordinates\\\": [ 555,  555 ] }\", \"description\": \"스팟 본문\", \"rate\": 5.0, \"placeName\": \"장소 타이틀\", \"placeAddress\": \"장소구 장소면 장소리\"}";
 
         mockMvc.perform(multipart("/api/v1/spots")
             .file("files", image1.getBytes())
             .file("files", image2.getBytes())
             .file("mapStaticImageFile", mapStaticImage.getBytes())
-            .file("placeImageFile", placeImage.getBytes())
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .content(requestBody)
         ).andDo(document(
@@ -191,19 +179,15 @@ class SpotApiControllerTest {
             getDocumentResponse(),
             requestParts(
                 partWithName("files").description("Spot의 이미지 파일 (다중파일)"),
-                partWithName("mapStaticImageFile").description("Spot의 장소를 나타내는 지도 이미지 파일(필수x)"),
-                partWithName("placeImageFile").description("Spot의 장소를 나타내는 썸네일 이미지 파일(필수x)")
+                partWithName("mapStaticImageFile").description("Spot의 장소를 나타내는 지도 이미지 파일")
             ),
             requestFields(
                 fieldWithPath("pointJson").type(JsonFieldType.STRING)
                     .description("스팟의 위치를 나타내는 geojson"),
-                fieldWithPath("title").type(JsonFieldType.STRING).description("스팟의 제목"),
                 fieldWithPath("description").type(JsonFieldType.STRING).description("스팟의 본문"),
                 fieldWithPath("rate").type(JsonFieldType.NUMBER).description("스팟 관련 평점 정보"),
                 fieldWithPath("placeName").type(JsonFieldType.STRING).description("스팟 관련 장소 명"),
-                fieldWithPath("placeAddress").type(JsonFieldType.STRING).description("스팟 관련 장소 주소"),
-                fieldWithPath("placePointJson").type(JsonFieldType.STRING)
-                    .description("스팟 관련 장소의 위치를 나타내는 geojson")
+                fieldWithPath("placeAddress").type(JsonFieldType.STRING).description("스팟 관련 장소 주소")
             ),
             responseFields(
                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답의 본문 메시지")


### PR DESCRIPTION
## Motivation 🧐
스팟 생성 요청시 필요 없는 부분은 받지 않음으로서(특히 스팟과 플레이스의 중복된 이미지) 쓸데없이 네트워크 대역폭을 잡아먹지 않도록 변경
<br>

## Key Changes 🔑
- 현재 디자인상에 없느 스팟의 제목을 받지 않도록 변경
- 장소와 스팟의 point가 별도로 설정할수 없어서 place point json을 별도로 받지 않도록 변경
- 장소의 이미지가 스팟의 첫 번째 이미지가 되도록 변경 
<br>

## To Reviewers 🙏
- 동작 확인 단위 테스트 했어유
- 조금 빨리 리뷰해주시면 감사하겠습니다!