### PR TITLE
백엔드 응답 데이터 타입 수정에 따라 맞추기

### DIFF
--- a/frontend/src/app/_components/place/spot/Spot.tsx
+++ b/frontend/src/app/_components/place/spot/Spot.tsx
@@ -19,7 +19,7 @@ export default function Spot({
 }) {
   const {
     id,
-    image_url_list,
+    image_urls,
     description,
     owner_profile_image_url,
     owner_nickname,
@@ -49,7 +49,7 @@ export default function Spot({
       </div>
       <div className="px-6 flex flex-col gap-2">
         <ImageCarousel
-          images={image_url_list}
+          images={image_urls}
           label="스팟 이미지들"
           variant="thumbnail"
         />

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -57,6 +57,7 @@ export const courseSchema = z.object({
   owner_nickname: z.string(),
   owner_profile_image_url: z.string(),
   liked: z.boolean(),
+  following: z.boolean(),
 });
 
 export type TCourse = z.infer<typeof courseSchema>;
@@ -175,7 +176,7 @@ export type TRegion = z.infer<typeof regionSchema>;
 
 export const spotSchema = z.object({
   id: z.number().int(),
-  image_url_list: z.array(z.string()),
+  image_urls: z.array(z.string()),
   description: z.string(),
   owner_id: z.number().int(),
   owner_profile_image_url: z.string(),
@@ -183,6 +184,7 @@ export const spotSchema = z.object({
   rate: z.number(),
   create_date: z.coerce.date(),
   liked: z.boolean(),
+  following: z.boolean(),
 });
 
 export type TSpot = z.infer<typeof spotSchema>;


### PR DESCRIPTION
## Motivation 🧐
백엔드 API 응답 데이터 타입이 변경되어 관련된 부분을 수정합니다.

## Key Changes 🔑
- `Spot` 스키마의 `image_url_list` 컬럼명을 `image_urls`로 변경하였습니다.
- `Spot`, `Course` 스키마에 `following` 컬럼을 추가하였습니다.

## To Reviewers 🙏
