### PR TITLE
장소 상세 화면에서 각 Travel 작성자를 팔로우/언팔로우할 수 있는 기능 추가

### DIFF
--- a/frontend/src/app/(with-header)/(home)/LoggedOutHome.tsx
+++ b/frontend/src/app/(with-header)/(home)/LoggedOutHome.tsx
@@ -8,7 +8,7 @@ import HomeFAB from './HomeFAB';
 export default function LoggedOutHome() {
   return (
     <main className="max-w-full flex flex-col gap-6 relative">
-      <Suspense fallback={<DummyPlaces title="관심 지역" variant="primary" />}>
+      <Suspense fallback={<DummyPlaces title="인기" variant="primary" />}>
         <PopularPlaces />
       </Suspense>
       <DummyPlaces

--- a/frontend/src/app/_components/place/FollowButton.tsx
+++ b/frontend/src/app/_components/place/FollowButton.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { toggleFollowTravelOwner } from './places/action';
+import ToastMsg from '../ui/toast/ToastMsg';
+import Spinner from '../ui/Spinner';
+
+export default function FollowButton({
+  ownerId,
+  initialFollowing,
+}: {
+  ownerId: number;
+  initialFollowing: boolean;
+}) {
+  const [following, setFollowing] = useState(initialFollowing);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function toggleFollow() {
+    setIsLoading(true);
+
+    const result = await toggleFollowTravelOwner(ownerId, following);
+
+    if (result.status === 'failed') {
+      setError(result.message);
+      setTimeout(() => setError(''), 2000);
+      setIsLoading(false);
+      return;
+    }
+
+    setFollowing(!following);
+    setIsLoading(false);
+  }
+
+  return (
+    <button
+      className={`p-2 ${following ? '' : 'text-blue-500'}`}
+      onClick={toggleFollow}
+    >
+      {isLoading ? <Spinner size="w-6 h-6" /> : following ? '팔로잉' : '팔로우'}
+      {error && <ToastMsg id={Date.now()} title={error} timer={2000} />}
+    </button>
+  );
+}

--- a/frontend/src/app/_components/place/course/Course.tsx
+++ b/frontend/src/app/_components/place/course/Course.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useContext } from 'react';
+import { MemberContext } from '@/context/MemberContext';
 import Image from 'next/image';
 
 import RoundProfile from '../../ui/profile/RoundProfile';
 import IconWithCounts from '../../IconWithCounts';
+
+import FollowButton from '../FollowButton';
 import Reaction from '../../reaction/Reaction';
 
 import type { TCourse } from '@/types/response';
@@ -17,29 +21,35 @@ export default function Course({
   placeId: number;
   data: TCourse;
 }) {
+  const memberStatus = useContext(MemberContext);
   const {
     id: travelId,
     title,
     map_static_image_url,
+    owner_id,
     owner_nickname,
     owner_profile_image_url,
     rate,
     create_date,
     content,
     liked,
-    owner_id,
+    following,
   } = data;
 
   return (
     <article className="py-2 flex flex-col gap-4">
       <div className="px-4 flex justify-between items-center">
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-1 items-center">
           <RoundProfile
             img={owner_profile_image_url}
             size={40}
             height="h-[40px]"
           />
-          <span>{owner_nickname}</span>
+          <span className="pl-2 text-lg font-medium">{owner_nickname}</span>
+          {memberStatus.isLoggedIn === 'true' &&
+            memberStatus.member.member_id !== owner_id && (
+              <FollowButton ownerId={owner_id} initialFollowing={following} />
+            )}
         </div>
         <IconWithCounts
           icon={

--- a/frontend/src/app/_components/place/spot/Spot.tsx
+++ b/frontend/src/app/_components/place/spot/Spot.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useContext } from 'react';
+import { MemberContext } from '@/context/MemberContext';
+
 import IconWithCounts from '../../IconWithCounts';
 import RoundProfile from '../../ui/profile/RoundProfile';
 import ImageCarousel from '../../ui/carousel/ImageCarousel';
 
+import FollowButton from '../FollowButton';
 import Reaction from '../../reaction/Reaction';
 
 import StarIcon from '/public/icons/star.svg';
@@ -17,27 +21,34 @@ export default function Spot({
   placeId: number;
   data: TSpot;
 }) {
+  const memberStatus = useContext(MemberContext);
   const {
-    id,
+    id: spotId,
     image_urls,
     description,
+    owner_id,
     owner_profile_image_url,
     owner_nickname,
     rate,
     liked,
     create_date,
+    following,
   } = data;
 
   return (
     <article className="py-2 flex flex-col gap-4">
       <div className="px-4 flex justify-between items-center">
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-1 items-center">
           <RoundProfile
             img={owner_profile_image_url}
             size={40}
             height="h-[40px]"
           />
-          <span>{owner_nickname}</span>
+          <span className="pl-2 text-lg font-medium">{owner_nickname}</span>
+          {memberStatus.isLoggedIn === 'true' &&
+            memberStatus.member.member_id !== owner_id && (
+              <FollowButton ownerId={owner_id} initialFollowing={following} />
+            )}
         </div>
         <IconWithCounts
           icon={
@@ -58,7 +69,7 @@ export default function Spot({
         </span>
         <div className="p-4 min-h-32 rounded-lg bg-gray-100">{description}</div>
       </div>
-      <Reaction placeId={placeId} travelId={id} initialLiked={liked} />
+      <Reaction placeId={placeId} travelId={spotId} initialLiked={liked} />
     </article>
   );
 }


### PR DESCRIPTION
## Motivation 🧐
장소 상세 화면의 각 Spot/Course 작성자를 팔로우/언팔로우할 수 있도록 UI와 기능을 추가했습니다.

## Key Changes 🔑
- 현재 팔로우 상태에 따라 문구가 바뀌는 버튼을 추가했습니다. 해당 버튼은 비로그인 시, 작성자가 본인일 경우에는 표시되지 않습니다.
- 현재 팔로우 상태에 따라 팔로우/언팔로우하는 서버 액션을 추가했습니다. 해당 기능은 #655 에서 이미 개발되었지만, PR 승인이 늦춰졌으므로 별도로 작성해넣었습니다.
- 백엔드 API 응답을 파싱하는 로직을 별도의 함수로 분리하여 `util.ts`에 위치시켰습니다. 해당 함수는 응답에 성공했을 때 파싱에 사용할 스키마(타입 TSomething)와 파싱할 json 객체를 입력으로 받아 `TBackendRequestResult<TSomething>`을 반환하는 함수입니다.

## To Reviewers 🙏
