### PR TITLE
API 응답 컬럼명 수정

### DIFF
--- a/frontend/src/app/_components/mypage/course/CourseDetail.tsx
+++ b/frontend/src/app/_components/mypage/course/CourseDetail.tsx
@@ -56,7 +56,7 @@ export default function CourseDetail({
     map_static_image_url,
     description,
     line_string_json,
-    create_date,
+    created_date,
   } = courseDetail;
 
   const [isMapOpen, setIsMapOpen] = useState(false);
@@ -326,7 +326,7 @@ export default function CourseDetail({
             </button>
           </div>
           <span className="self-end text-gray-400 font-medium">
-            {create_date}
+            {created_date}
           </span>
           <div className="my-4 flex flex-col gap-4">
             {isModifyMode ? (

--- a/frontend/src/types/myPageResponse.ts
+++ b/frontend/src/types/myPageResponse.ts
@@ -101,7 +101,7 @@ export const mypageCourseDetailSchema = z.object({
   map_static_image_url: z.string(),
   description: z.string(),
   line_string_json: z.string().transform((json) => JSON.parse(json)),
-  create_date: z.coerce
+  created_date: z.coerce
     .date()
     .transform((date) => date.toLocaleDateString('ko-kr')),
   spots: z.array(myPageCourseDetailSpotSchema),


### PR DESCRIPTION
## Motivation 🧐
API 응답과 프론트엔드에서 받는 스키마 간의 컬럼명이 맞지 않아 오류가 발생하는 현상을 수정합니다.

## Key Changes 🔑
- `myPageCourseDetailSchema`의 `create_date`를 `created_date`로 수정합니다.

## To Reviewers 🙏
