### PR TITLE
feat: 로그인 실패 시 로그인화면 에러 출력

### DIFF
--- a/frontend/src/app/(without-header)/login/page.tsx
+++ b/frontend/src/app/(without-header)/login/page.tsx
@@ -1,5 +1,3 @@
-export const dynamic = 'force-dynamic';
-
 import React from 'react';
 
 import KakaoBtn from '@/app/_components/ui/button/Kakao';
@@ -11,7 +9,11 @@ import GoogleLoginButton from '@/app/_components/ui/button/GoogleLoginButton';
 import NaverLoginButton from '@/app/_components/ui/button/NaverLoginButton';
 import { googleOAuthEndPoint } from '@/app/endpoints/api/auth/callback/google/constants';
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: { status: string };
+}) {
   const { KAKAO_ID, GOOGLE_CLIENT_ID, NAVER_SEARCH_ID } = process.env;
 
   const kakaoHref = await kakaoOAuthEndpoint(KAKAO_ID);
@@ -24,8 +26,15 @@ export default async function LoginPage() {
         containerStyle="w-full flex justify-end h-1/6 mr-6 mt-5"
         style="cursor-pointer w-12 h-12 stroke-2 stroke-black hover:stroke-gray-700 active:stroke-gray-500"
       />
-      <div className="h-2/6">
+      <div className="h-2/6 flex flex-col justify-stretch">
         <LoginLogo className="w-[290px] h-[96px]" />
+        <div className="grow"></div>
+        {searchParams?.status === 'failed' && (
+          <div className="text-center pb-5 text-white font-semibold animate-appear">
+            로그인에 실패했습니다. <br />
+            다시 시도해주세요.
+          </div>
+        )}
       </div>
       <div className="w-full mx-7 h-2/6">
         <div className="w-full flex gap-x-4 px-8  relative ">

--- a/frontend/src/app/_components/ui/button/CloseButton.tsx
+++ b/frontend/src/app/_components/ui/button/CloseButton.tsx
@@ -8,10 +8,10 @@ interface TButtonProps {
 }
 
 export default function CloseButton({ containerStyle, style }: TButtonProps) {
-  const router = useRouter();
+  const { push } = useRouter();
 
   return (
-    <button className={containerStyle} onClick={() => router.back()}>
+    <button className={containerStyle} onClick={() => push('/')}>
       <XLogo className={style} />
     </button>
   );

--- a/frontend/src/app/endpoints/api/auth/callback/kakao/route.ts
+++ b/frontend/src/app/endpoints/api/auth/callback/kakao/route.ts
@@ -8,16 +8,15 @@ import {
 } from './constants';
 
 export async function GET(request: NextRequest) {
+  const baseUrl = await getCallbackUrlBase();
   const { searchParams } = new URL(request.url);
 
   const code = searchParams.get('code');
 
-  if (!code) {
-    return NextResponse.json(
-      { message: 'Failed to get Authorization codew' },
-      { status: 400 },
+  if (!code)
+    return NextResponse.redirect(
+      new URL('/login?status=failed&reason=code', baseUrl),
     );
-  }
 
   const { KAKAO_ID, KAKAO_SECRET, ENVIRONMENT } = process.env;
 
@@ -36,9 +35,8 @@ export async function GET(request: NextRequest) {
   if (!userTokenResponse.ok) {
     console.log(userTokenJson);
 
-    return NextResponse.json(
-      { message: 'Failed to get token' },
-      { status: 400 },
+    return NextResponse.redirect(
+      new URL('/login?status=failed&reason=userinfo', baseUrl),
     );
   }
 
@@ -52,9 +50,8 @@ export async function GET(request: NextRequest) {
   if (!userInfoResponse.ok) {
     console.log(userInfoJson);
 
-    return NextResponse.json(
-      { message: 'Failed to get token' },
-      { status: 400 },
+    return NextResponse.redirect(
+      new URL('/login?status=failed&reason=userinfo', baseUrl),
     );
   }
 
@@ -80,9 +77,8 @@ export async function GET(request: NextRequest) {
 
   if (!backendResponse.ok) {
     console.log(backendJson);
-    return NextResponse.json(
-      { message: 'Failed to login to backend server' },
-      { status: 400 },
+    return NextResponse.redirect(
+      new URL('/login?status=failed&reason=server', baseUrl),
     );
   }
 
@@ -90,8 +86,6 @@ export async function GET(request: NextRequest) {
     .getSetCookie()[0]
     .split('; ')[0]
     .split('=');
-
-  const baseUrl = await getCallbackUrlBase();
 
   const response = NextResponse.redirect(new URL('/', baseUrl), {
     status: 302,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -19,6 +19,7 @@ module.exports = {
       },
       animation: {
         appear: 'appear .5s ease-in-out',
+        bounceOne: 'bounce 1.2s ease-in-out',
       },
     },
   },


### PR DESCRIPTION
## Motivation 🧐
로그인 실패의 경우가 4가지 있는데 각 경우에 대해 `NextReponse.redirect`를 이용해 login화면으로 리다이렉트 시키며, `searchParams`로 상태를 보여줬습니다.
`status`를 `failed`로 처리해 실패했다는 것을 나타내고 화면에 에러 문구를 출력했습니다.
`reason` 이라는 `searchParam`으로 현재 에러에 대해 얻어오는 정보에서의 에러인지 백엔드와의 통신 에러인지 `code`, `userinfo`, `server` 세 가지 경우로 처리했습니다.
<br>

## Key Changes 🔑

<br>

## To Reviewers 🙏
